### PR TITLE
Gen 7 Save Read/Write Capabilities

### DIFF
--- a/src/types/SAVTypes/GEN7.ts
+++ b/src/types/SAVTypes/GEN7.ts
@@ -1,0 +1,102 @@
+import { PK7 } from 'pokemon-files';
+import { GameOfOrigin } from 'pokemon-resources';
+import { bytesToUint16LittleEndian, uint16ToBytesLittleEndian } from '../../util/ByteLogic';
+import { CRC16_CCITT } from '../../util/Encryption';
+import { utf16BytesToString } from '../../util/Strings/StringConverter';
+import { OHPKM } from '../pkm/OHPKM';
+import { SaveType } from '../types';
+import { Box, SAV } from './SAV';
+import { ParsedPath } from './path';
+
+const SM_PC_OFFSET = 0x4E00; // Box start offset for Gen 7
+const SM_PC_CHECKSUM_OFFSET = 0x656C2; // Gen 7 checksum offset for boxes
+const BOX_NAMES_OFFSET: number = 0x04800; // Box names offset for Gen 7
+const BOX_SIZE: number = 232 * 30; // Each box has 30 slots, each Pokémon slot is 232 bytes
+
+export class G7SAV extends SAV<PK7> {
+  trainerDataOffset: number = 0x14000;
+
+  boxes: Array<Box<PK7>>;
+
+  saveType = SaveType.G7;
+
+  boxChecksumOffset: number = SM_PC_CHECKSUM_OFFSET;
+
+  pcOffset = SM_PC_OFFSET;
+  pcChecksumOffset = SM_PC_CHECKSUM_OFFSET;
+
+  constructor(path: ParsedPath, bytes: Uint8Array) {
+    super(path, bytes);
+    this.name = utf16BytesToString(this.bytes, this.trainerDataOffset + 0x38, 0x12);
+    this.tid = bytesToUint16LittleEndian(this.bytes, this.trainerDataOffset);
+    this.sid = bytesToUint16LittleEndian(this.bytes, this.trainerDataOffset + 2);
+    this.currentPCBox = this.bytes[0];
+    this.displayID = this.tid.toString().padStart(5, '0');
+    this.origin = this.bytes[this.trainerDataOffset + 4];
+
+    // Set up for Game Version Sun (30) or Moon (31) specifics if needed
+    switch (this.origin) {
+      case GameOfOrigin.Sun:
+      case GameOfOrigin.Moon:
+        this.pcOffset = SM_PC_OFFSET;
+        this.pcChecksumOffset = SM_PC_CHECKSUM_OFFSET;
+        break;
+    }
+
+    this.boxes = Array(32);
+    for (let box = 0; box < 32; box++) {
+      const boxName = utf16BytesToString(this.bytes, BOX_NAMES_OFFSET + 34 * box, 17);
+      this.boxes[box] = new Box(boxName, 30);
+    }
+
+    for (let box = 0; box < 32; box++) {
+      for (let monIndex = 0; monIndex < 30; monIndex++) {
+        try {
+          const startByte = this.pcOffset + BOX_SIZE * box + 232 * monIndex;
+          const endByte = this.pcOffset + BOX_SIZE * box + 232 * (monIndex + 1);
+          const monData = bytes.slice(startByte, endByte);
+          const mon = new PK7(monData.buffer, true);
+          if (mon.gameOfOrigin !== 0 && mon.dexNum !== 0) {
+            this.boxes[box].pokemon[monIndex] = mon;
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+  }
+
+  prepareBoxesForSaving() {
+    const changedMonPKMs: OHPKM[] = [];
+    this.updatedBoxSlots.forEach(({ box, index }) => {
+      const changedMon = this.boxes[box].pokemon[index];
+      // Only save changed OHPKM slots
+      if (changedMon instanceof OHPKM) {
+        changedMonPKMs.push(changedMon);
+      }
+      const writeIndex = this.pcOffset + BOX_SIZE * box + 232 * index;
+      if (changedMon) {
+        try {
+          const mon = changedMon instanceof OHPKM ? new PK7(changedMon) : changedMon;
+          if (mon?.gameOfOrigin && mon?.dexNum) {
+            mon.refreshChecksum();
+            this.bytes.set(new Uint8Array(mon.toPCBytes()), writeIndex);
+          }
+        } catch (e) {
+          console.error(e);
+        }
+      } else {
+        const mon = new PK7(new Uint8Array(232).buffer);
+        this.bytes.set(new Uint8Array(mon.toPCBytes()), writeIndex);
+      }
+    });
+
+    // Compute checksum for Gen 7 data structure and update save file
+    this.bytes.set(
+      uint16ToBytesLittleEndian(CRC16_CCITT(this.bytes, this.pcOffset, 0x34ad0)),
+      this.pcChecksumOffset
+    );
+
+    return changedMonPKMs;
+  }
+}

--- a/src/types/SAVTypes/GEN7.ts
+++ b/src/types/SAVTypes/GEN7.ts
@@ -2,6 +2,7 @@ import { PK7 } from 'pokemon-files';
 import { GameOfOrigin } from 'pokemon-resources';
 import {
   SM_TRANSFER_RESTRICTIONS
+  USUM_TRANSFER_RESTRICTIONS
 } from '../../consts/TransferRestrictions';
 import {
   bytesToUint16LittleEndian,
@@ -58,7 +59,7 @@ export class G7SAV extends SAV<PK7> {
         break;
       case GameOfOrigin.UltraSun:
       case GameOfOrigin.UltraMoon:
-        this.transferRestrictions = SM_TRANSFER_RESTRICTIONS;
+        this.transferRestrictions = USUM_TRANSFER_RESTRICTIONS;
     }
 
     this.boxes = Array(32);


### PR DESCRIPTION
**Description**

First off this is a really cool application. This absolutely satisfies that collecting itch that PKHex DB doesn't quit fulfill. 

This commit provides the foundation for parsing gen 7 saves. The next steps are to implement the Gen 7 saves into OpenHome. This shouldn't be too hard, but its going to require more study from myself in order to do it. I got the byte offsets from [PKHex](https://github.com/kwsch/PKHeX/blob/master/PKHeX.Core/PKM/PK7.cs). I used the Gen 6 save typescript file as a foundation for this. The Gen 6 & 7 files are very similar in structure so this wasn't too hard.

Anyways, I can't wait to see Gen 7 file read/write implemented and hopefully this commit speeds along the progress.