### PR TITLE
fix: storage files not initializing on windows

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -89,6 +89,7 @@ fn init_storage_json_file(
 ) -> Result<(), String> {
     let absolute_path = util::prepend_appdata_storage_to_path(app_handle, &relative_path)?;
     if !Path::new(&absolute_path).exists() {
+        util::create_openhome_directory(app_handle)?;
         let mut file = File::create(&absolute_path).map_err(|e| e.to_string())?;
         if is_array {
             file.write_all(b"[]").map_err(|e| e.to_string())?;

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashSet, fs::File, io::Read, path::PathBuf};
+use std::{collections::HashSet, io::Read, path::PathBuf};
+use std::fs::{File, create_dir_all};
 use serde;
 use tauri::Manager;
 
@@ -79,4 +80,16 @@ pub fn dedupe_paths(paths: Vec<PathData>) -> Vec<PathData> {
         .into_iter()
         .filter(|path| seen.insert(path.raw.clone()))
         .collect()
+}
+
+pub fn create_openhome_directory(app_handle: &tauri::AppHandle) -> Result<(), String> {
+    
+    let appdata_dir = get_appdata_dir(app_handle)?;
+    let mut full_path = PathBuf::new();
+
+    full_path.push(appdata_dir);
+    full_path.push("storage".to_owned());
+
+    create_dir_all(full_path).unwrap();
+    Ok(())
 }

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -90,6 +90,6 @@ pub fn create_openhome_directory(app_handle: &tauri::AppHandle) -> Result<(), St
     full_path.push(appdata_dir);
     full_path.push("storage".to_owned());
 
-    create_dir_all(full_path).unwrap();
+    create_dir_all(full_path).map_err(|e| e.to_string())?;
     Ok(())
 }


### PR DESCRIPTION
This fixes the issue for windows platform where app crashes due to storage directory not being created when running the app for the first time. Now it creates the storage directory first before creating Json files.
