### PR TITLE
fix: incomplete path data + broken "reveal in file explorer"

### DIFF
--- a/src/backend/backendInterface.ts
+++ b/src/backend/backendInterface.ts
@@ -45,7 +45,7 @@ export default interface BackendInterface {
   rollbackTransaction: () => Promise<Errorable<null>>
 
   /* application */
-  pickFile: () => Promise<Errorable<string | undefined>>
+  pickFile: () => Promise<Errorable<PathData | undefined>>
   pickFolder: () => Promise<Errorable<string | undefined>>
   getResourcesPath: () => Promise<string>
   openDirectory: (directory: string) => Promise<Errorable<null>>

--- a/src/backend/tauri/tauriBackend.ts
+++ b/src/backend/tauri/tauriBackend.ts
@@ -126,11 +126,17 @@ export const TauriBackend: BackendInterface = {
 
     const validatedSaves: Record<string, SaveRef> = {}
 
+    let modified = false
+
     for (let [rawPath, saveRef] of Object.entries(result.right)) {
       if (!saveRef.filePath.dir) {
         saveRef.filePath = await pathDataFromRaw(rawPath)
+        modified = true
       }
 
+      if (modified) {
+        TauriInvoker.writeStorageFileJSON('recent_saves.json', validatedSaves)
+      }
       validatedSaves[rawPath] = saveRef
     }
 

--- a/src/backend/tauri/tauriBackend.ts
+++ b/src/backend/tauri/tauriBackend.ts
@@ -12,6 +12,22 @@ import { Errorable, JSONObject, LoadSaveResponse, LookupMap, SaveRef } from 'src
 import { Settings } from '../../state/appInfo'
 import { TauriInvoker } from './tauriInvoker'
 
+async function pathDataFromRaw(raw: string): Promise<PathData> {
+  const filename = await path.basename(raw)
+  const dir = await path.dirname(raw)
+  const ext = await path.extname(raw)
+
+  const pathData: PathData = {
+    raw,
+    name: filename,
+    separator: path.sep(),
+    dir,
+    ext,
+  }
+
+  return pathData
+}
+
 export const TauriBackend: BackendInterface = {
   /* past gen identifier lookups */
   loadGen12Lookup: function (): Promise<Errorable<LookupMap>> {
@@ -185,10 +201,11 @@ export const TauriBackend: BackendInterface = {
   },
 
   /* application */
-  pickFile: async (): Promise<Errorable<string | undefined>> => {
-    const path = await fileDialog({ directory: false, title: 'Select File' })
+  pickFile: async (): Promise<Errorable<PathData | undefined>> => {
+    const filePath = await fileDialog({ directory: false, title: 'Select File' })
 
-    return E.right(path ?? undefined)
+    if (!filePath) return E.right(undefined)
+    return E.right(await pathDataFromRaw(filePath))
   },
   pickFolder: async (): Promise<Errorable<string | undefined>> => {
     const path = await fileDialog({ directory: true, title: 'Select Folder' })

--- a/src/saves/SavesModal.tsx
+++ b/src/saves/SavesModal.tsx
@@ -47,7 +47,8 @@ const SavesModal = (props: SavesModalProps) => {
           console.error(pickedFile.left)
           return
         }
-        filePath = { raw: pickedFile.right } as PathData
+        if (!pickedFile.right) return
+        filePath = pickedFile.right
       }
       backend.loadSaveFile(filePath).then(
         E.match(

--- a/src/types/SAVTypes/G3SAV.ts
+++ b/src/types/SAVTypes/G3SAV.ts
@@ -10,7 +10,7 @@ import {
 } from 'src/util/byteLogic'
 import { gen3StringToUTF } from 'src/util/Strings/StringConverter'
 import { OHPKM } from '../pkm/OHPKM'
-import { emptyPathData, PathData, splitPath } from './path'
+import { emptyPathData, PathData } from './path'
 import { Box, BoxCoordinates, SAV } from './SAV'
 import { LOOKUP_TYPE } from './util'
 
@@ -255,8 +255,7 @@ export class G3SAV implements SAV<PK3> {
     if (trainerMon) {
       this.origin = trainerMon?.gameOfOrigin
     } else {
-      const filePathElements = splitPath(this.filePath)
-      let fileName = filePathElements[filePathElements.length - 1]
+      let fileName = this.filePath.name
 
       fileName = fileName.replace(/\s+/g, '')
       if (fileName.includes('Ruby')) {

--- a/src/types/SAVTypes/__test__/G3RRSAV.test.ts
+++ b/src/types/SAVTypes/__test__/G3RRSAV.test.ts
@@ -32,11 +32,9 @@ describe('G3RRSAV - Radical Red Save File Read Test', () => {
 
     const parsedPath: PathData = {
       raw: './SAVFILES/radicalred.sav',
-      base: '.SAVFILES/radical red.sav',
       name: 'radical red',
       dir: './SAVFILES',
       ext: '.sav',
-      root: '/',
       separator: '/',
     }
 
@@ -125,11 +123,9 @@ describe('G3RRSAV - Radical Red Save File Write Test', () => {
 
     const parsedPath: PathData = {
       raw: './SAVFILES/radicalred.sav',
-      base: '.SAVFILES/radicalred.sav',
       name: 'radical red',
       dir: './SAVFILES',
       ext: '.sav',
-      root: '/',
       separator: '/',
     }
 
@@ -168,11 +164,9 @@ describe('G3RRSAV - Radical Red Save File Write Test', () => {
   test('should check if modifications were made', () => {
     const parsedPath: PathData = {
       raw: './SAVFILES/radicalred_modified.sav',
-      base: '.SAVFILES/radicalred_modified.sav',
       name: 'radical red',
       dir: './SAVFILES',
       ext: '.sav',
-      root: '/',
       separator: '/',
     }
 

--- a/src/types/SAVTypes/__test__/G7SAV.test.ts
+++ b/src/types/SAVTypes/__test__/G7SAV.test.ts
@@ -14,11 +14,9 @@ describe('gen 7 save files', () => {
 
     const parsedPath: PathData = {
       raw: './SAVFILES/ultrasun',
-      base: '.SAVFILES/ultrasun',
       name: 'ultrasun',
       dir: './SAVFILES',
       ext: '',
-      root: '/',
       separator: '/',
     }
 

--- a/src/types/SAVTypes/path.ts
+++ b/src/types/SAVTypes/path.ts
@@ -1,29 +1,21 @@
 export type PathData = {
   raw: string
-  base: string
   name: string
   dir: string
   ext: string
-  root: string
-  separator: '\\' | '/'
+  separator: string
 }
 
 export const emptyPathData: PathData = {
   raw: '',
-  base: '',
   dir: '',
   name: '',
   separator: '/',
   ext: '',
-  root: '',
-}
-
-export function joinPath(path: PathData) {
-  return [path.dir, path.name].join(path.separator) + path.ext
 }
 
 export function splitPath(path: PathData) {
-  return [path.root, ...path.dir.split(path.separator).filter((seg) => seg !== ''), path.name]
+  return [...path.dir.split(path.separator).filter((seg) => seg !== ''), path.name]
 }
 
 export type PossibleSaves = {


### PR DESCRIPTION
**Description**

- Fixed the issue where "reveal in file explorer/finder" did not work for files opened after v1.0.0
  - The bug: I was lazy when migrating to Tauri and used a type assertion to avoid providing a full PathData object, when that was necessary to get the file's directory
  - Incomplete data in `recent_saves.json` is automatically fixed in this version

**Issue**

Fixes #76 
