### PR TITLE
feat: option to override app theme

### DIFF
--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -97,13 +97,11 @@ pub fn create_menu(app: &App) -> Result<Menu<Wry>, Box<dyn std::error::Error>> {
     )?;
 
     let help_submenu = SubmenuBuilder::new(handle, "Help")
-        // .item(&about_item)
         .item(&check_updates_item)
         .item(&visit_github_item)
         .build()?;
 
     menu.append(&help_submenu)?;
-
     Ok(menu)
 }
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -61,10 +61,10 @@ pub fn prepend_appdata_storage_to_path(
 }
 
 pub fn get_storage_file_text(
-    app_handle: tauri::AppHandle,
+    app_handle: &tauri::AppHandle,
     relative_path: &PathBuf,
 ) -> Result<String, String> {
-    let full_path = prepend_appdata_storage_to_path(&app_handle, relative_path)?;
+    let full_path = prepend_appdata_storage_to_path(app_handle, relative_path)?;
 
     // Open the file, and return any error up the call stack
     let mut file = File::open(full_path).map_err(|e| e.to_string())?;
@@ -74,6 +74,15 @@ pub fn get_storage_file_text(
         .map_err(|e| e.to_string())?;
 
     return Ok(contents);
+}
+
+pub fn get_storage_file_json(
+    app_handle: &tauri::AppHandle,
+    relative_path: &PathBuf,
+) -> Result<serde_json::Value, String> {
+    let json_data = get_storage_file_text(app_handle, relative_path)?;
+    return serde_json::from_str(json_data.as_str())
+        .map_err(|e| format!("error opening {:#?}: {e}", relative_path));
 }
 
 pub fn get_appdata_dir(app_handle: &tauri::AppHandle) -> Result<String, String> {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -77,8 +77,9 @@ export default function App() {
   }, [backend])
 
   useEffect(() => {
+    if (!appInfoState.settingsLoaded) return
     backend.updateSettings(appInfoState.settings).catch(console.error)
-  }, [appInfoState.settings, backend])
+  }, [appInfoState.settings, appInfoState.settingsLoaded, backend])
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/app/Settings.tsx
+++ b/src/app/Settings.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@mui/joy'
+import { Button, Card, ToggleButtonGroup } from '@mui/joy'
 import { useContext, useEffect } from 'react'
 import { BackendContext } from '../backend/backendContext'
 import { AppInfoContext } from '../state/appInfo'
@@ -14,9 +14,7 @@ export default function Settings() {
   return (
     <div>
       <Card variant="outlined" sx={{ m: 1, maxWidth: 400 }}>
-        <div>
-          <b>Enabled ROM Hack Formats</b>
-        </div>
+        <b>Enabled ROM Hack Formats</b>
         <div>
           {appInfoState.extraSaveTypes.map((saveType) => (
             <label style={{ display: 'flex', flexDirection: 'row' }} key={saveType.saveTypeName}>
@@ -34,6 +32,28 @@ export default function Settings() {
             </label>
           ))}
         </div>
+
+        <b>App Theme</b>
+        <ToggleButtonGroup
+          onChange={(_, newValue) => {
+            if (!newValue) return
+            backend.setTheme(newValue)
+            dispatchAppInfoState({ type: 'set_app_theme', payload: newValue })
+          }}
+          color="primary"
+          variant="soft"
+          value={appInfoState.settings.appTheme}
+        >
+          <Button fullWidth value="system">
+            System
+          </Button>
+          <Button fullWidth value="light">
+            Light
+          </Button>
+          <Button fullWidth value="dark">
+            Dark
+          </Button>
+        </ToggleButtonGroup>
       </Card>
     </div>
   )

--- a/src/app/Themes.ts
+++ b/src/app/Themes.ts
@@ -46,7 +46,7 @@ export const components: Components<Theme> = {
         padding: 0,
         minHeight: ownerState.size === 'sm' ? 0 : undefined,
         height: 'fit-content',
-        borderRadius: 3,
+        '--Button-radius': '3px',
       }),
     },
   },

--- a/src/backend/backendInterface.ts
+++ b/src/backend/backendInterface.ts
@@ -54,6 +54,7 @@ export default interface BackendInterface {
   getState: () => Promise<Errorable<AppState>>
   getSettings: () => Promise<Errorable<Settings>>
   updateSettings: (settings: Settings) => Promise<Errorable<null>>
+  setTheme(appTheme: 'light' | 'dark' | 'system'): Promise<Errorable<null>>
 }
 
 export interface BackendListeners {

--- a/src/backend/dummyBackend.ts
+++ b/src/backend/dummyBackend.ts
@@ -44,6 +44,7 @@ const DummyBackend: BackendInterface = {
   getState: async () => E.left('no backend in use'),
   getSettings: async () => E.left('no backend in use'),
   updateSettings: async () => E.left('no backend in use'),
+  setTheme: async () => E.left('no backend in use'),
 }
 
 export default DummyBackend

--- a/src/backend/tauri/tauriBackend.ts
+++ b/src/backend/tauri/tauriBackend.ts
@@ -270,13 +270,16 @@ export const TauriBackend: BackendInterface = {
     return promise.then(
       E.match(
         (err) => E.left(err),
-        (partialSettings) => E.right({ enabledSaveTypes: {}, ...partialSettings })
+        (partialSettings) =>
+          E.right({ enabledSaveTypes: {}, appTheme: 'system', ...partialSettings })
       )
     )
   },
   updateSettings: async (settings: Settings) => {
     return TauriInvoker.writeStorageFileJSON('settings.json', settings as JSONObject)
   },
+  setTheme: (appTheme: 'light' | 'dark' | 'system'): Promise<Errorable<null>> =>
+    TauriInvoker.setTheme(appTheme),
 
   registerListeners: (listeners) => {
     const unlistenPromise = Promise.all([

--- a/src/backend/tauri/tauriInvoker.tsx
+++ b/src/backend/tauri/tauriInvoker.tsx
@@ -123,4 +123,10 @@ export const TauriInvoker = {
 
     return promise.then(E.right).catch(E.left)
   },
+
+  setTheme(appTheme: 'light' | 'dark' | 'system'): Promise<Errorable<null>> {
+    const promise: Promise<null> = invoke('set_app_theme', { appTheme })
+
+    return promise.then(E.right).catch(E.left)
+  },
 }

--- a/src/state/appInfo.ts
+++ b/src/state/appInfo.ts
@@ -16,11 +16,13 @@ import { XYSAV } from '../types/SAVTypes/XYSAV'
 
 export type Settings = {
   enabledSaveTypes: Record<string, boolean>
+  appTheme: 'light' | 'dark' | 'system'
 }
 
 export type AppInfoState = {
   resourcesPath?: string
   settings: Settings
+  settingsLoaded: boolean
   officialSaveTypes: SAVClass[]
   extraSaveTypes: SAVClass[]
 }
@@ -40,6 +42,10 @@ export type AppInfoAction =
   | {
       type: 'load_settings'
       payload: Settings
+    }
+  | {
+      type: 'set_app_theme'
+      payload: 'light' | 'dark' | 'system'
     }
 
 export const appInfoReducer: Reducer<AppInfoState, AppInfoAction> = (
@@ -80,6 +86,9 @@ export const appInfoReducer: Reducer<AppInfoState, AppInfoAction> = (
 
       return { ...state, settings: { ...payload, enabledSaveTypes: enabled } }
     }
+    case 'set_app_theme': {
+      return { ...state, settings: { ...state.settings, appTheme: payload }, settingsLoaded: true }
+    }
   }
 }
 
@@ -102,7 +111,9 @@ export const appInfoInitialState: AppInfoState = {
         G3RRSAV,
       ].map((savetype) => [savetype.saveTypeID, true])
     ),
+    appTheme: 'system',
   },
+  settingsLoaded: false,
 
   officialSaveTypes: [
     G1SAV,


### PR DESCRIPTION
**Description**

App theme (light/dark) can now be overridden in Settings

**Issue**

Fixes #61 
