### PR TITLE
chore: error modal styling + displayError hook

### DIFF
--- a/src/app/App.css
+++ b/src/app/App.css
@@ -186,6 +186,18 @@ button > svg {
     rgba(0, 0, 0, 0.23) 0px 3px 6px !important;
 }
 
+@media (prefers-color-scheme: light) {
+  .MuiTabPanel-root {
+    ::-webkit-scrollbar-thumb {
+      background-color: #7dceab;
+    }
+  }
+}
+
+.datagrid {
+  border: none;
+}
+
 .datagrid-error-row {
   background-color: #f004;
 }

--- a/src/app/ErrorMessage.tsx
+++ b/src/app/ErrorMessage.tsx
@@ -1,12 +1,4 @@
-import {
-  Alert,
-  DialogContent,
-  DialogTitle,
-  Divider,
-  Modal,
-  ModalClose,
-  ModalDialog,
-} from '@mui/joy'
+import { Alert, DialogContent, DialogTitle, Modal, ModalClose, ModalDialog } from '@mui/joy'
 import { useContext } from 'react'
 import { ErrorIcon } from 'src/components/Icons'
 import { ErrorContext } from '../state/error'
@@ -21,14 +13,16 @@ export default function ErrorMessageModal() {
     >
       <ModalDialog style={{ padding: 8 }}>
         <ModalClose />
-        <DialogTitle>{errorState.messageData?.title}</DialogTitle>
-        <Divider />
+        <DialogTitle style={{ marginBottom: 8, fontSize: 20 }}>
+          {errorState.messageData?.title}
+        </DialogTitle>
         <DialogContent>
           {errorState.messageData?.messages?.map((msg, i) => (
             <Alert
               startDecorator={<ErrorIcon style={{ width: 20, height: 20 }} />}
               color="danger"
-              size="sm"
+              size="lg"
+              sx={{ padding: 1, fontWeight: 'bold' }}
               variant="solid"
               key={`alert_${i}`}
             >

--- a/src/hooks/displayError.ts
+++ b/src/hooks/displayError.ts
@@ -1,0 +1,20 @@
+import { useCallback, useContext } from 'react'
+import { ErrorContext } from '../state/error'
+
+export default function useDisplayError() {
+  const [, dispatchErrorState] = useContext(ErrorContext)
+
+  const displayError = useCallback(
+    (title: string, messages: string | string[]) =>
+      dispatchErrorState({
+        type: 'set_message',
+        payload: {
+          title,
+          messages: typeof messages === 'string' ? [messages] : messages,
+        },
+      }),
+    [dispatchErrorState]
+  )
+
+  return displayError
+}

--- a/src/saves/RecentSaves.tsx
+++ b/src/saves/RecentSaves.tsx
@@ -38,7 +38,10 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
   const getRecentSaves = useCallback(() => {
     backend.getRecentSaves().then(
       E.match(
-        (err) => displayError('Error Getting Recents', err),
+        (err) => {
+          displayError('Error Getting Recents', err)
+          setRecentSaves({})
+        },
         (recents) => {
           const extraSaveIdentifiers = getEnabledSaveTypes()
             .map(getPluginIdentifier)

--- a/src/saves/RecentSaves.tsx
+++ b/src/saves/RecentSaves.tsx
@@ -1,4 +1,4 @@
-import { DialogActions, Modal, ModalDialog, Stack, Typography } from '@mui/joy'
+import { Stack } from '@mui/joy'
 import * as E from 'fp-ts/lib/Either'
 import { GameOfOrigin } from 'pokemon-resources'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
@@ -9,8 +9,8 @@ import { filterUndefined, numericSorter } from 'src/util/Sort'
 import { BackendContext } from '../backend/backendContext'
 import { ErrorIcon } from '../components/Icons'
 import OHDataGrid, { SortableColumn } from '../components/OHDataGrid'
+import useDisplayError from '../hooks/displayError'
 import { AppInfoContext } from '../state/appInfo'
-import { ErrorContext } from '../state/error'
 import { OpenSavesContext } from '../state/openSaves'
 import SaveCard from './SaveCard'
 import SaveDetailsMenu from './SaveDetailsMenu'
@@ -28,8 +28,7 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
   const [recentSaves, setRecentSaves] = useState<Record<string, SaveRef>>()
   const [, , openSaves] = useContext(OpenSavesContext)
   const [, , getEnabledSaveTypes] = useContext(AppInfoContext)
-  const [error, setError] = useState<string>()
-  const [, dispatchErrorState] = useContext(ErrorContext)
+  const displayError = useDisplayError()
 
   const openSavePaths = useMemo(
     () => Object.fromEntries(openSaves.map((save) => [save.filePath.raw, true])),
@@ -39,11 +38,7 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
   const getRecentSaves = useCallback(() => {
     backend.getRecentSaves().then(
       E.match(
-        (err) =>
-          dispatchErrorState({
-            type: 'set_message',
-            payload: { title: 'Error Getting Recents', messages: [err] },
-          }),
+        (err) => displayError('Error Getting Recents', err),
         (recents) => {
           const extraSaveIdentifiers = getEnabledSaveTypes()
             .map(getPluginIdentifier)
@@ -59,19 +54,19 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
         }
       )
     )
-  }, [backend, dispatchErrorState, getEnabledSaveTypes])
+  }, [backend, displayError, getEnabledSaveTypes])
 
   const removeRecentSave = useCallback(
     (path: string) =>
       backend.removeRecentSave(path).then(
         E.match(
           async (err) => {
-            setError(err)
+            displayError('Could Not Remove Save', err)
           },
           () => getRecentSaves()
         )
       ),
-    [backend, getRecentSaves]
+    [backend, getRecentSaves, displayError]
   )
 
   const saveTypeFromOrigin = useCallback(
@@ -122,13 +117,7 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
           <button
             className="save-grid-error-button"
             onClick={() =>
-              dispatchErrorState({
-                type: 'set_message',
-                payload: {
-                  title: 'Invalid Save',
-                  messages: ['File is missing, renamed, or inaccessbile'],
-                },
-              })
+              displayError('Invalid Save', 'File is missing, renamed, or inaccessbile')
             }
           >
             <ErrorIcon style={{ width: 20, height: 20 }} />
@@ -206,44 +195,32 @@ export default function RecentSaves(props: SaveFileSelectorProps) {
     },
   ]
 
-  return (
-    <>
-      {view === 'grid' ? (
-        <OHDataGrid
-          rows={Object.values(recentSaves ?? {}).map((save, i) => ({
-            ...save,
-            index: i,
-          }))}
-          columns={columns}
-          defaultSort="lastOpened"
-          defaultSortDir="DESC"
-          rowClass={(row) => (row.valid ? undefined : 'datagrid-error-row')}
-        />
-      ) : (
-        <Stack flexWrap="wrap" direction="row" useFlexGap justifyContent="center" margin={2}>
-          {Object.values(recentSaves ?? {})
-            .sort((a, b) => (b.lastOpened ?? 0) - (a.lastOpened ?? 0))
-            .map((save) => (
-              <SaveCard
-                key={save.filePath.raw}
-                save={save}
-                onOpen={() => {
-                  onOpen(save.filePath)
-                }}
-                onRemove={() => removeRecentSave(save.filePath.raw)}
-                size={cardSize}
-              />
-            ))}
-        </Stack>
-      )}
-      <Modal open={!!error} onClose={() => setError(undefined)}>
-        <ModalDialog>
-          <Typography>{error}</Typography>
-          <DialogActions>
-            <button onClick={() => setError(undefined)}>OK</button>
-          </DialogActions>
-        </ModalDialog>
-      </Modal>
-    </>
+  return view === 'grid' ? (
+    <OHDataGrid
+      rows={Object.values(recentSaves ?? {}).map((save, i) => ({
+        ...save,
+        index: i,
+      }))}
+      columns={columns}
+      defaultSort="lastOpened"
+      defaultSortDir="DESC"
+      rowClass={(row) => (row.valid ? undefined : 'datagrid-error-row')}
+    />
+  ) : (
+    <Stack flexWrap="wrap" direction="row" useFlexGap justifyContent="center" margin={2}>
+      {Object.values(recentSaves ?? {})
+        .sort((a, b) => (b.lastOpened ?? 0) - (a.lastOpened ?? 0))
+        .map((save) => (
+          <SaveCard
+            key={save.filePath.raw}
+            save={save}
+            onOpen={() => {
+              onOpen(save.filePath)
+            }}
+            onRemove={() => removeRecentSave(save.filePath.raw)}
+            size={cardSize}
+          />
+        ))}
+    </Stack>
   )
 }

--- a/src/saves/SaveCard.tsx
+++ b/src/saves/SaveCard.tsx
@@ -1,9 +1,9 @@
 import { Button, Card, Chip, Stack } from '@mui/joy'
 import { GameOfOrigin, isGameBoy } from 'pokemon-resources'
 import { useContext, useMemo, useState } from 'react'
-import { ErrorContext } from 'src/state/error'
 import { SaveRef } from 'src/types/types'
 import { ErrorIcon } from '../components/Icons'
+import useDisplayError from '../hooks/displayError'
 import { AppInfoContext } from '../state/appInfo'
 import { getGameColor, getPluginIdentifier } from '../types/SAVTypes/util'
 import SaveDetailsMenu from './SaveDetailsMenu'
@@ -23,7 +23,7 @@ const standardViewMinSize = 180
 
 export default function SaveCard({ save, onOpen, onRemove, size = 240 }: SaveCardProps) {
   const [expanded, setExpanded] = useState(false)
-  const [, dispatchErrorState] = useContext(ErrorContext)
+  const displayError = useDisplayError()
   const [, , getEnabledSaveTypes] = useContext(AppInfoContext)
 
   const gbBackground = useMemo(() => (save.game ? isGameBoy(save.game) : false), [save.game])
@@ -149,13 +149,7 @@ export default function SaveCard({ save, onOpen, onRemove, size = 240 }: SaveCar
           <button
             className="save-grid-error-button"
             onClick={() =>
-              dispatchErrorState({
-                type: 'set_message',
-                payload: {
-                  title: 'Invalid Save',
-                  messages: ['File is missing, renamed, or inaccessbile'],
-                },
-              })
+              displayError('Invalid Save', 'File is missing, renamed, or inaccessbile')
             }
             style={{
               filter: 'none',

--- a/src/saves/boxes/BoxCell.tsx
+++ b/src/saves/boxes/BoxCell.tsx
@@ -5,7 +5,7 @@ import { MonLocation } from 'src/state/openSaves'
 import { bytesToPKM } from 'src/types/FileImport'
 import { filterApplies } from 'src/types/Filter'
 import { PKMInterface } from 'src/types/interfaces'
-import { ErrorContext } from '../../state/error'
+import useDisplayError from '../../hooks/displayError'
 import '../style.css'
 import DraggableMon from './DraggableMon'
 import DroppableSpace from './DroppableSpace'
@@ -32,7 +32,7 @@ const BoxCell = ({
   dragData,
 }: BoxCellProps) => {
   const [filterState] = useContext(FilterContext)
-  const [, dispatchErrorState] = useContext(ErrorContext)
+  const displayError = useDisplayError()
 
   const isFilteredOut = useMemo(() => {
     return (
@@ -52,10 +52,7 @@ const BoxCell = ({
       try {
         importedMons.push(bytesToPKM(bytes, extension.toUpperCase()))
       } catch (e) {
-        dispatchErrorState({
-          type: 'set_message',
-          payload: { title: 'Error Importing Pokémon', messages: [`${e}`] },
-        })
+        displayError('Error Importing Pokémon', `${e}`)
       }
     }
     onDrop(importedMons)


### PR DESCRIPTION
**Description**

- Error display modal has been updated to display better on all platforms
- A new `displayError` hook has been added to avoid verbose calls to `dispatchErrorState()`
- Grid scrollbar updated to be teal in light mode (was white and not visible before)
