### PR TITLE
Download Sprites as Resource Packs

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-shell",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -33,6 +34,17 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -78,6 +90,15 @@ name = "anyhow"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ashpd"
@@ -284,6 +305,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +398,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -412,6 +456,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +513,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -534,6 +594,21 @@ checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -642,6 +717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +730,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -672,6 +764,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1424,6 +1517,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +1959,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -1983,10 +2103,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "lockfree-object-pool"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
 
 [[package]]
 name = "mac"
@@ -2588,6 +2724,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -3436,6 +3582,17 @@ checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
 dependencies = [
  "nodrop",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -5405,6 +5562,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
 
 [[package]]
 name = "zerovec"
@@ -5426,6 +5597,77 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "zip"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "hmac",
+ "indexmap 2.6.0",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "rand 0.8.5",
+ "sha1",
+ "thiserror 2.0.3",
+ "time",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zopfli"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "lockfree-object-pool",
+ "log",
+ "once_cell",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7,6 +7,7 @@ name = "OpenHome"
 version = "1.1.0"
 dependencies = [
  "dirs",
+ "reqwest",
  "serde",
  "serde_json",
  "tauri",
@@ -15,6 +16,7 @@ dependencies = [
  "tauri-plugin-fs",
  "tauri-plugin-os",
  "tauri-plugin-shell",
+ "tokio",
 ]
 
 [[package]]
@@ -154,6 +156,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -412,9 +420,9 @@ dependencies = [
  "bitflags 2.6.0",
  "block",
  "cocoa-foundation",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
  "objc",
 ]
@@ -427,7 +435,7 @@ checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
 dependencies = [
  "bitflags 2.6.0",
  "block",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
  "libc",
  "objc",
@@ -470,6 +478,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
@@ -491,9 +509,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -504,7 +522,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -914,12 +932,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -932,6 +959,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -965,6 +998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1335,6 +1369,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.6.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1486,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1441,6 +1495,39 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2000,6 +2087,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,6 +2446,50 @@ dependencies = [
  "is-wsl",
  "libc",
  "pathdiff",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2884,25 +3032,34 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-util",
  "tower-service",
  "url",
@@ -2937,6 +3094,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3137,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2977,6 +3188,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3017,6 +3237,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3277,7 +3520,7 @@ dependencies = [
  "bytemuck",
  "cfg_aliases",
  "core-graphics",
- "foreign-types",
+ "foreign-types 0.5.0",
  "js-sys",
  "log",
  "objc2",
@@ -3315,6 +3558,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -3359,6 +3608,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swift-rs"
@@ -3423,6 +3678,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3443,7 +3719,7 @@ checksum = "6682a07cf5bab0b8a2bd20d0a542917ab928b5edb75ebd4eda6b05cbaab872da"
 dependencies = [
  "bitflags 2.6.0",
  "cocoa",
- "core-foundation",
+ "core-foundation 0.10.0",
  "core-graphics",
  "crossbeam-channel",
  "dispatch",
@@ -3914,11 +4190,45 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "tracing",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.89",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -4145,6 +4455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,6 +4511,12 @@ dependencies = [
  "getrandom 0.2.15",
  "serde",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -5077,6 +5399,12 @@ dependencies = [
  "syn 2.0.89",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,4 +26,5 @@ tauri-plugin-os = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2"
 dirs = "5.0.1"
-
+reqwest = { version = "0.12", features = ["blocking"] }
+tokio = { version = "1", features = ["full"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,3 +28,4 @@ tauri-plugin-fs = "2"
 dirs = "5.0.1"
 reqwest = { version = "0.12", features = ["blocking"] }
 tokio = { version = "1", features = ["full"] }
+zip = "2.2.2"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -266,7 +266,7 @@ pub fn validate_recent_saves(
 pub fn download_sprite_pack(
     app_handle: tauri::AppHandle,
     github_folder_url: String,
-    target_folder: String,
+    target_sprite_pack: String,
 ) -> Result<(), String> {
     create_openhome_directory(&app_handle)?;
 
@@ -274,7 +274,7 @@ pub fn download_sprite_pack(
     fs::create_dir_all(&sprites_dir)
         .map_err(|e| format!("Failed to create sprites directory: {}", e))?;
 
-    let target_path = sprites_dir.join(&target_folder);
+    let target_path = sprites_dir.join(&target_sprite_pack);
 
     let save_dir = target_path
         .to_str()
@@ -290,9 +290,12 @@ pub fn download_sprite_pack(
 }
 
 #[tauri::command]
-pub fn delete_sprite_pack(app_handle: tauri::AppHandle, folder_name: String) -> Result<(), String> {
+pub fn delete_sprite_pack(
+    app_handle: tauri::AppHandle,
+    target_sprite_pack: String,
+) -> Result<(), String> {
     let sprites_dir = prepend_appdata_storage_to_path(&app_handle, &PathBuf::from("sprites"))?;
-    let folder_path = sprites_dir.join(&folder_name);
+    let folder_path = sprites_dir.join(&target_sprite_pack);
 
     // Make sure folder exists
     if !folder_path.exists() {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,7 +11,7 @@ use tauri::Manager;
 use crate::saves;
 use crate::state::{AppState, AppStateSnapshot};
 use crate::util::{
-    self, create_openhome_directory, download_images_from_github_folder,
+    self, create_openhome_directory, download_and_unpack_zip, download_images_from_github_folder,
     prepend_appdata_storage_to_path,
 };
 
@@ -282,7 +282,7 @@ pub fn download_sprite_pack(
 
     println!("{}", save_dir);
 
-    download_images_from_github_folder(&github_folder_url, save_dir)
+    download_and_unpack_zip(&github_folder_url, save_dir)
         .map_err(|e| format!("Failed to download images: {}", e))?;
 
     println!("Images downloaded to: {}", save_dir);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -11,7 +11,8 @@ use tauri::Manager;
 use crate::saves;
 use crate::state::{AppState, AppStateSnapshot};
 use crate::util::{
-    self, create_openhome_directory, download_and_unpack_zip, download_images_from_github_folder,
+    self, create_openhome_directory,
+    download_and_unpack_zip, /*download_images_from_github_folder,*/
     prepend_appdata_storage_to_path,
 };
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -60,6 +60,8 @@ pub fn run() {
             commands::find_suggested_saves,
             commands::set_app_theme,
             commands::validate_recent_saves,
+            commands::download_sprite_pack,
+            commands::delete_sprite_pack,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -131,20 +131,12 @@ pub fn download_images_from_github_folder(
         .text()?;
 
     let files: serde_json::Value = serde_json::from_str(&response)?;
-    let file_urls: Vec<&str> = files
+    let file_urls = files
         .as_array()
         .unwrap()
         .iter()
-        .filter_map(|file| {
-            if let Some(file_name) = file.get("name") {
-                // makes sure non image don't sneak in and are downloaded
-                if file_name.as_str()?.ends_with(".png") {
-                    return file.get("download_url")?.as_str();
-                }
-            }
-            None
-        })
-        .collect();
+        .filter_map(|file| file.get("download_url")?.as_str())
+        .filter(|url| url.ends_with(".png"));
 
     fs::create_dir_all(save_dir)?;
 

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -1,10 +1,8 @@
 use reqwest::blocking::Client;
-use reqwest::Url;
 use serde;
-use std::fs;
-use std::fs::{create_dir_all, File};
 use std::{
     collections::HashSet,
+    fs::{self, create_dir_all, File},
     io::{self, Read, Write},
     path::{Path, PathBuf},
 };
@@ -119,44 +117,44 @@ pub fn create_openhome_directory(app_handle: &tauri::AppHandle) -> Result<(), St
     Ok(())
 }
 
-pub fn download_images_from_github_folder(
-    folder_url: &str,
-    save_dir: &str,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let client = Client::new();
+// pub fn download_images_from_github_folder(
+//     folder_url: &str,
+//     save_dir: &str,
+// ) -> Result<(), Box<dyn std::error::Error>> {
+//     let client = Client::new();
 
-    let response = client
-        .get(folder_url)
-        .header("User-Agent", "OpenHome")
-        .send()?
-        .text()?;
+//     let response = client
+//         .get(folder_url)
+//         .header("User-Agent", "OpenHome")
+//         .send()?
+//         .text()?;
 
-    let files: serde_json::Value = serde_json::from_str(&response)?;
-    let file_urls = files
-        .as_array()
-        .unwrap()
-        .iter()
-        .filter_map(|file| file.get("download_url")?.as_str())
-        .filter(|url| url.ends_with(".png"));
+//     let files: serde_json::Value = serde_json::from_str(&response)?;
+//     let file_urls = files
+//         .as_array()
+//         .unwrap()
+//         .iter()
+//         .filter_map(|file| file.get("download_url")?.as_str())
+//         .filter(|url| url.ends_with(".png"));
 
-    fs::create_dir_all(save_dir)?;
+//     fs::create_dir_all(save_dir)?;
 
-    for url in file_urls {
-        let parsed_url = Url::parse(url)?;
-        let image_name = parsed_url
-            .path_segments()
-            .and_then(|segments| segments.last())
-            .unwrap();
+//     for url in file_urls {
+//         let parsed_url = Url::parse(url)?;
+//         let image_name = parsed_url
+//             .path_segments()
+//             .and_then(|segments| segments.last())
+//             .unwrap();
 
-        let response = client.get(url).send()?;
-        let mut file = fs::File::create(format!("{}/{}", save_dir, image_name))?;
-        file.write_all(&response.bytes()?)?;
-        println!("Downloaded: {}", image_name);
-    }
+//         let response = client.get(url).send()?;
+//         let mut file = fs::File::create(format!("{}/{}", save_dir, image_name))?;
+//         file.write_all(&response.bytes()?)?;
+//         println!("Downloaded: {}", image_name);
+//     }
 
-    println!("All images downloaded successfully!");
-    Ok(())
-}
+//     println!("All images downloaded successfully!");
+//     Ok(())
+// }
 
 pub fn download_and_unpack_zip(
     zip_url: &str,

--- a/src/app/Settings.tsx
+++ b/src/app/Settings.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, ToggleButtonGroup } from '@mui/joy'
-import { useContext, useEffect } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { BackendContext } from '../backend/backendContext'
 import { AppInfoContext } from '../state/appInfo'
 
@@ -7,9 +7,32 @@ export default function Settings() {
   const [appInfoState, dispatchAppInfoState] = useContext(AppInfoContext)
   const backend = useContext(BackendContext)
 
+  // Feedback
+  const [feedback, setFeedback] = useState<string | null>(null)
+
   useEffect(() => {
     backend.updateSettings(appInfoState.settings).catch(console.error)
   }, [appInfoState.settings, backend])
+
+  const handleDownload = async () => {
+    setFeedback("Downloading sprite pack...")
+    const result = await backend.downloadSpritePack('gen1')
+    if (result._tag === 'Right') {
+      setFeedback("Sprite pack downloaded successfully!")
+    } else {
+      setFeedback(`Error downloading sprite pack: ${result.left}`)
+    }
+  }
+
+  const handleDelete = async () => {
+    setFeedback("Deleting sprite pack...")
+    const result = await backend.deleteSpritePack('gen1')
+    if (result._tag === 'Right') {
+      setFeedback("Sprite pack deleted successfully!")
+    } else {
+      setFeedback(`Error deleting sprite pack: ${result.left}`)
+    }
+  }
 
   return (
     <div>
@@ -54,6 +77,17 @@ export default function Settings() {
             Dark
           </Button>
         </ToggleButtonGroup>
+
+        <div style={{ marginTop: '16px' }}>
+          <Button onClick={handleDownload} color="success" sx={{ marginRight: '8px' }}>
+            Download Sprite Pack
+          </Button>
+          <Button onClick={handleDelete} color="danger">
+            Delete Sprite Pack
+          </Button>
+        </div>
+
+        {feedback && <p style={{ marginTop: '16px' }}>{feedback}</p>}
       </Card>
     </div>
   )

--- a/src/app/Settings.tsx
+++ b/src/app/Settings.tsx
@@ -1,96 +1,153 @@
-import { Button, Card, ToggleButtonGroup } from '@mui/joy'
+import { Box, Button, Card, Stack, ToggleButtonGroup } from '@mui/joy'
 import { useContext, useEffect, useState } from 'react'
+import { SAVClass } from 'src/types/SAVTypes/util'
 import { BackendContext } from '../backend/backendContext'
+import { getRelevantGameLogos } from '../images/game'
+import { getPublicImageURL } from '../images/images'
 import { AppInfoContext } from '../state/appInfo'
 
 export default function Settings() {
   const [appInfoState, dispatchAppInfoState] = useContext(AppInfoContext)
   const backend = useContext(BackendContext)
-
-  // Feedback
   const [feedback, setFeedback] = useState<string | null>(null)
+  const [downloadStatus, setDownloadStatus] = useState<Record<string, boolean>>({})
 
   useEffect(() => {
     backend.updateSettings(appInfoState.settings).catch(console.error)
   }, [appInfoState.settings, backend])
 
-  const handleDownload = async () => {
-    setFeedback('Downloading sprite pack...')
-    const result = await backend.downloadSpritePack('gen1')
+  const handleDownload = async (saveTypeID: string) => {
+    setFeedback(`Downloading sprite pack for ${saveTypeID}...`)
+    const result = await backend.downloadSpritePack(saveTypeID)
 
     if (result._tag === 'Right') {
-      setFeedback('Sprite pack downloaded successfully!')
+      setFeedback(`Sprite pack for ${saveTypeID} downloaded successfully!`)
+      setDownloadStatus((prev) => ({ ...prev, [saveTypeID]: true }))
     } else {
-      setFeedback(`Error downloading sprite pack: ${result.left}`)
+      setFeedback(`Error downloading sprite pack for ${saveTypeID}: ${result.left}`)
     }
   }
 
-  const handleDelete = async () => {
-    setFeedback('Deleting sprite pack...')
-    const result = await backend.deleteSpritePack('gen1')
+  const handleDelete = async (saveTypeID: string) => {
+    setFeedback(`Deleting sprite pack for ${saveTypeID}...`)
+    const result = await backend.deleteSpritePack(saveTypeID)
 
     if (result._tag === 'Right') {
-      setFeedback('Sprite pack deleted successfully!')
+      setFeedback(`Sprite pack for ${saveTypeID} deleted successfully!`)
+      setDownloadStatus((prev) => ({ ...prev, [saveTypeID]: false }))
     } else {
-      setFeedback(`Error deleting sprite pack: ${result.left}`)
+      setFeedback(`Error deleting sprite pack for ${saveTypeID}: ${result.left}`)
     }
+  }
+
+  const handleBoxClick = async (saveType: SAVClass) => {
+    const saveTypeID: string = saveType.saveTypeID
+    if (downloadStatus[saveTypeID]) {
+      await handleDelete(saveTypeID)
+    } else {
+      await handleDownload(saveTypeID)
+    }
+    dispatchAppInfoState({
+      type: 'set_sprite_pack_downloaded',
+      payload: { saveType: saveType, downloaded: !downloadStatus[saveTypeID] },
+    })
   }
 
   return (
     <div>
-      <Card variant="outlined" sx={{ m: 1, maxWidth: 400 }}>
-        <b>Enabled ROM Hack Formats</b>
-        <div>
-          {appInfoState.extraSaveTypes.map((saveType) => (
-            <label style={{ display: 'flex', flexDirection: 'row' }} key={saveType.saveTypeName}>
-              <input
-                type="checkbox"
-                onChange={(e) =>
-                  dispatchAppInfoState({
-                    type: 'set_savetype_enabled',
-                    payload: { saveType, enabled: e.target.checked },
-                  })
-                }
-                checked={appInfoState.settings.enabledSaveTypes[saveType.saveTypeID]}
-              />
-              {saveType.saveTypeName}
-            </label>
-          ))}
-        </div>
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ padding: 2 }}>
+        <Card variant="outlined" sx={{ m: 1, maxWidth: 450 }}>
+          <b>Enabled ROM Hack Formats</b>
+          <div>
+            {appInfoState.extraSaveTypes.map((saveType) => (
+              <label style={{ display: 'flex', flexDirection: 'row' }} key={saveType.saveTypeName}>
+                <input
+                  type="checkbox"
+                  onChange={(e) =>
+                    dispatchAppInfoState({
+                      type: 'set_savetype_enabled',
+                      payload: { saveType, enabled: e.target.checked },
+                    })
+                  }
+                  checked={appInfoState.settings.enabledSaveTypes[saveType.saveTypeID]}
+                />
+                {saveType.saveTypeName}
+              </label>
+            ))}
+          </div>
 
-        <b>App Theme</b>
-        <ToggleButtonGroup
-          onChange={(_, newValue) => {
-            if (!newValue) return
-            backend.setTheme(newValue)
-            dispatchAppInfoState({ type: 'set_app_theme', payload: newValue })
-          }}
-          color="primary"
-          variant="soft"
-          value={appInfoState.settings.appTheme}
-        >
-          <Button fullWidth value="system">
-            System
-          </Button>
-          <Button fullWidth value="light">
-            Light
-          </Button>
-          <Button fullWidth value="dark">
-            Dark
-          </Button>
-        </ToggleButtonGroup>
-
-        <div style={{ marginTop: '16px' }}>
-          <Button onClick={handleDownload} color="success" sx={{ marginRight: '8px' }}>
-            Download Sprite Pack
-          </Button>
-          <Button onClick={handleDelete} color="danger">
-            Delete Sprite Pack
-          </Button>
-        </div>
-
-        {feedback && <p style={{ marginTop: '16px' }}>{feedback}</p>}
-      </Card>
+          <b>App Theme</b>
+          <ToggleButtonGroup
+            onChange={(_, newValue) => {
+              if (!newValue) return
+              backend.setTheme(newValue)
+              dispatchAppInfoState({ type: 'set_app_theme', payload: newValue })
+            }}
+            color="primary"
+            variant="soft"
+            value={appInfoState.settings.appTheme}
+          >
+            <Button fullWidth value="system">
+              System
+            </Button>
+            <Button fullWidth value="light">
+              Light
+            </Button>
+            <Button fullWidth value="dark">
+              Dark
+            </Button>
+          </ToggleButtonGroup>
+        </Card>
+        <Card variant="outlined" sx={{ m: 1, maxWidth: 400 }}>
+          <b>Sprite Packs</b>
+          <Box
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(auto-fit, minmax(100px, 1fr))',
+              gap: 2,
+              padding: 2,
+            }}
+          >
+            {appInfoState.officialSaveTypes.map((saveType) => {
+              const logos = getRelevantGameLogos(saveType.saveTypeName)
+              return (
+                <Box
+                  key={saveType.saveTypeID}
+                  onClick={() => handleBoxClick(saveType)}
+                  sx={{
+                    backgroundColor: downloadStatus[saveType.saveTypeID] ? 'green' : 'red',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    transition: 'background-color 0.2s',
+                    padding: 2,
+                    position: 'relative',
+                    borderRadius: '8px',
+                    overflow: 'hidden',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {logos.map((logo, index) => (
+                    <img
+                      key={index}
+                      src={getPublicImageURL(logo)}
+                      alt={`${saveType.saveTypeName} Logo`}
+                      style={{
+                        width: '80%',
+                        height: 'auto',
+                        objectFit: 'contain',
+                        marginBottom: 4,
+                      }}
+                    />
+                  ))}
+                </Box>
+              )
+            })}
+          </Box>
+          {feedback && <p style={{ marginTop: '16px' }}>{feedback}</p>}
+        </Card>
+      </Stack>
     </div>
   )
 }

--- a/src/app/Settings.tsx
+++ b/src/app/Settings.tsx
@@ -15,20 +15,22 @@ export default function Settings() {
   }, [appInfoState.settings, backend])
 
   const handleDownload = async () => {
-    setFeedback("Downloading sprite pack...")
+    setFeedback('Downloading sprite pack...')
     const result = await backend.downloadSpritePack('gen1')
+
     if (result._tag === 'Right') {
-      setFeedback("Sprite pack downloaded successfully!")
+      setFeedback('Sprite pack downloaded successfully!')
     } else {
       setFeedback(`Error downloading sprite pack: ${result.left}`)
     }
   }
 
   const handleDelete = async () => {
-    setFeedback("Deleting sprite pack...")
+    setFeedback('Deleting sprite pack...')
     const result = await backend.deleteSpritePack('gen1')
+
     if (result._tag === 'Right') {
-      setFeedback("Sprite pack deleted successfully!")
+      setFeedback('Sprite pack deleted successfully!')
     } else {
       setFeedback(`Error deleting sprite pack: ${result.left}`)
     }

--- a/src/backend/backendInterface.ts
+++ b/src/backend/backendInterface.ts
@@ -55,6 +55,10 @@ export default interface BackendInterface {
   getSettings: () => Promise<Errorable<Settings>>
   updateSettings: (settings: Settings) => Promise<Errorable<null>>
   setTheme(appTheme: 'light' | 'dark' | 'system'): Promise<Errorable<null>>
+
+  /* sprite packs */
+  downloadSpritePack: (targetSpritePack: string) => Promise<Errorable<null>>
+  deleteSpritePack: (targetSpritePack: string) => Promise<Errorable<null>>
 }
 
 export interface BackendListeners {

--- a/src/backend/dummyBackend.ts
+++ b/src/backend/dummyBackend.ts
@@ -29,6 +29,7 @@ const DummyBackend: BackendInterface = {
   getSaveFolders: async () => E.left('no backend in use'),
   removeSaveFolder: async () => E.left('no backend in use'),
   upsertSaveFolder: async () => E.left('no backend in use'),
+
   /* transactions */
   startTransaction: async () => E.left('no backend in use'),
   commitTransaction: async () => E.left('no backend in use'),
@@ -45,6 +46,9 @@ const DummyBackend: BackendInterface = {
   getSettings: async () => E.left('no backend in use'),
   updateSettings: async () => E.left('no backend in use'),
   setTheme: async () => E.left('no backend in use'),
+
+  downloadSpritePack: async () => E.left('no backend in use'),
+  deleteSpritePack: async () => E.left('no backend in use'),
 }
 
 export default DummyBackend

--- a/src/backend/tauri/tauriBackend.ts
+++ b/src/backend/tauri/tauriBackend.ts
@@ -33,6 +33,15 @@ async function pathDataFromRaw(raw: string): Promise<PathData> {
 type OnDropEvent = Event<{ position: { x: number; y: number }; paths: string[] }>
 
 export const TauriBackend: BackendInterface = {
+  // TODO: move to bottom of file
+  downloadSpritePack: function (targetSpritePack: string): Promise<Errorable<null>> {
+    return TauriInvoker.downloadSpritePack(targetSpritePack) as Promise<Errorable<null>>
+  },
+
+  deleteSpritePack: function (targetSpritePack: string): Promise<Errorable<null>> {
+    return TauriInvoker.deleteSpritePack(targetSpritePack) as Promise<Errorable<null>>
+  },
+
   /* past gen identifier lookups */
   loadGen12Lookup: function (): Promise<Errorable<LookupMap>> {
     return TauriInvoker.getStorageFileJSON('gen12_lookup.json') as Promise<Errorable<LookupMap>>

--- a/src/backend/tauri/tauriInvoker.tsx
+++ b/src/backend/tauri/tauriInvoker.tsx
@@ -137,6 +137,7 @@ export const TauriInvoker = {
   },
 
   downloadSpritePack(targetSpritePack: string): Promise<Errorable<null>> {
+    // TODO: For zips this url will be https://raw.githubusercontent.com/repos/andrewbenington/OpenHomeZIPS/${targetSpritePack}.zip
     const githubFolderUrl: String = `https://api.github.com/repos/andrewbenington/OpenHome/contents/public/sprites/${targetSpritePack}`
     const promise: Promise<null> = invoke('download_sprite_pack', {
       githubFolderUrl,

--- a/src/backend/tauri/tauriInvoker.tsx
+++ b/src/backend/tauri/tauriInvoker.tsx
@@ -135,4 +135,19 @@ export const TauriInvoker = {
 
     return promise.then(E.right).catch(E.left)
   },
+
+  downloadSpritePack(githubFolderUrl: string, targetFolder: string): Promise<Errorable<null>> {
+    const promise: Promise<null> = invoke('download_sprite_pack', {
+      githubFolderUrl,
+      targetFolder,
+    });
+
+    return promise.then(E.right).catch(E.left);
+  },
+
+  deleteSpritePack(folderName: string): Promise<Errorable<null>> {
+    const promise: Promise<null> = invoke('delete_sprite_pack', { folderName });
+
+    return promise.then(E.right).catch(E.left);
+  },
 }

--- a/src/backend/tauri/tauriInvoker.tsx
+++ b/src/backend/tauri/tauriInvoker.tsx
@@ -141,16 +141,14 @@ export const TauriInvoker = {
     const promise: Promise<null> = invoke('download_sprite_pack', {
       githubFolderUrl,
       targetSpritePack,
-    });
-    console.log(promise)
+    })
 
-
-    return promise.then(E.right).catch(E.left);
+    return promise.then(E.right).catch(E.left)
   },
 
   deleteSpritePack(targetSpritePack: string): Promise<Errorable<null>> {
-    const promise: Promise<null> = invoke('delete_sprite_pack', { targetSpritePack });
+    const promise: Promise<null> = invoke('delete_sprite_pack', { targetSpritePack })
 
-    return promise.then(E.right).catch(E.left);
+    return promise.then(E.right).catch(E.left)
   },
 }

--- a/src/backend/tauri/tauriInvoker.tsx
+++ b/src/backend/tauri/tauriInvoker.tsx
@@ -136,17 +136,20 @@ export const TauriInvoker = {
     return promise.then(E.right).catch(E.left)
   },
 
-  downloadSpritePack(githubFolderUrl: string, targetFolder: string): Promise<Errorable<null>> {
+  downloadSpritePack(targetSpritePack: string): Promise<Errorable<null>> {
+    const githubFolderUrl: String = `https://api.github.com/repos/andrewbenington/OpenHome/contents/public/sprites/${targetSpritePack}`
     const promise: Promise<null> = invoke('download_sprite_pack', {
       githubFolderUrl,
-      targetFolder,
+      targetSpritePack,
     });
+    console.log(promise)
+
 
     return promise.then(E.right).catch(E.left);
   },
 
-  deleteSpritePack(folderName: string): Promise<Errorable<null>> {
-    const promise: Promise<null> = invoke('delete_sprite_pack', { folderName });
+  deleteSpritePack(targetSpritePack: string): Promise<Errorable<null>> {
+    const promise: Promise<null> = invoke('delete_sprite_pack', { targetSpritePack });
 
     return promise.then(E.right).catch(E.left);
   },

--- a/src/images/game.ts
+++ b/src/images/game.ts
@@ -73,3 +73,13 @@ export const getGameLogo = (
 export const getOriginMark = (originMark: string) => {
   return `origin_marks/${originMark}.png`
 }
+
+export const getRelevantGameLogos = (saveTypeName: string): string[] => {
+  const gameNames = saveTypeName.split('/').map((name) => name.trim())
+  const logos = gameNames.map((gameName) => {
+    const logoKey = gameName.replace(' ', '')
+    return GameLogos[logoKey] ?? null
+  })
+  console.log(logos.filter((logo): logo is string => logo !== null))
+  return logos.filter((logo): logo is string => logo !== null)
+}

--- a/src/state/appInfo.ts
+++ b/src/state/appInfo.ts
@@ -36,6 +36,23 @@ export const defaultSettings: Settings = {
   saveCardSize: 180,
   saveViewMode: 'card',
   appTheme: 'system',
+  spritePacksDownloaded: Object.fromEntries(
+    [
+      G1SAV,
+      G2SAV,
+      G3SAV,
+      DPSAV,
+      PtSAV,
+      HGSSSAV,
+      BWSAV,
+      BW2SAV,
+      XYSAV,
+      ORASSAV,
+      SMSAV,
+      USUMSAV,
+      G3RRSAV,
+    ].map((savetype) => [savetype.saveTypeID, true])
+  ),
 }
 
 export type Settings = {
@@ -43,6 +60,7 @@ export type Settings = {
   saveCardSize: number
   saveViewMode: SaveViewMode
   appTheme: 'light' | 'dark' | 'system'
+  spritePacksDownloaded: Record<string, boolean>
 }
 
 export type AppInfoState = {
@@ -80,6 +98,13 @@ export type AppInfoAction =
   | {
       type: 'set_app_theme'
       payload: 'light' | 'dark' | 'system'
+    }
+  | {
+      type: 'set_sprite_pack_downloaded'
+      payload: {
+        saveType: SAVClass
+        downloaded: boolean
+      }
     }
 
 export const appInfoReducer: Reducer<AppInfoState, AppInfoAction> = (
@@ -134,6 +159,19 @@ export const appInfoReducer: Reducer<AppInfoState, AppInfoAction> = (
     }
     case 'set_app_theme': {
       return { ...state, settings: { ...state.settings, appTheme: payload }, settingsLoaded: true }
+    }
+    case 'set_sprite_pack_downloaded': {
+      const downloaded = state.settings.spritePacksDownloaded
+
+      if (payload.downloaded) {
+        downloaded[payload.saveType.saveTypeID] = true
+      } else {
+        downloaded[payload.saveType.saveTypeID] = false
+      }
+      return {
+        ...state,
+        settings: { ...state.settings, spritePacksDownloaded: downloaded },
+      }
     }
   }
 }


### PR DESCRIPTION
```
use std::fs;
use reqwest::blocking::Client;
use reqwest::Url;
use std::io::Write;

fn download_images_from_github_folder(
    folder_url: &str,
    save_dir: &str,
) -> Result<(), Box<dyn std::error::Error>> {
    let client = Client::new();

    let response = client
        .get(folder_url)
        .header("User-Agent", "OpenHome")
        .send()?
        .text()?;

    let files: serde_json::Value = serde_json::from_str(&response)?;
    let file_urls: Vec<&str> = files
        .as_array()
        .unwrap()
        .iter()
        .filter_map(|file| {
            if let Some(file_name) = file.get("name") {
                // Filter for .png files
                if file_name.as_str()?.ends_with(".png") {
                    return file.get("download_url")?.as_str();
                }
            }
            None
        })
        .collect();

    fs::create_dir_all(save_dir)?;

    for url in file_urls {
        let parsed_url = Url::parse(url)?;
        let image_name = parsed_url
            .path_segments()
            .and_then(|segments| segments.last())
            .unwrap();

        let response = client.get(url).send()?;
        let mut file = fs::File::create(format!("{}/{}", save_dir, image_name))?;
        file.write_all(&response.bytes()?)?;
        println!("Downloaded: {}", image_name);
    }

    println!("All images downloaded successfully!");
    Ok(())
}

fn main() {
    let github_folder_url = "https://api.github.com/repos/andrewbenington/OpenHome/contents/public/sprites/gen1";
    let save_dir = "./test_sprites";

    match download_images_from_github_folder(github_folder_url, save_dir) {
        Ok(_) => println!("Test successful! Images downloaded to: {}", save_dir),
        Err(e) => eprintln!("Test failed: {}", e),
    }
}
```

The only thing I've tested is `util::download_images_from_github_folder` using the above code.

@andrewbenington 