### PR TITLE
chore: clean up rust dependency features

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,17 +15,17 @@ name = "openhome_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
-tauri-build = { version = "2", features = [] }
+tauri-build = { version = "2"}
 
 [dependencies]
-tauri = { version = "2.1.1", features = [] }
+tauri = { version = "2.1.1" }
 tauri-plugin-shell = "2.2.0"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.134"
 tauri-plugin-os = "2.2.0"
 tauri-plugin-dialog = "2.2.0"
 tauri-plugin-fs = "2.2.0"
-reqwest = { version = "0.12.10", features = ["blocking"] }
+reqwest = { version = "0.12.10"}
 base64 = "0.22.1"
 zip = "2.2.2"
 bytes = "1.9.0"


### PR DESCRIPTION
I cleaned up the `cargo.toml` file and got rid of the `blocking` feature which is unused and unneeded. I don't think this has any affect on the final binary size since I believe cargo cuts out the unused code, but it might lessen the intermediate build size.