### PR TITLE
chore: optimize rust binary

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,18 @@
         "kind": "build",
         "isDefault": true
       }
+    },
+    {
+      "label": "clean",
+      "type": "shell",
+      "command": "cmd",
+      "args": ["/c", "del /s /q dist && cargo clean --manifest-path=./src-tauri/Cargo.toml"],
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "detail": "Cleans the dist folder and performs a cargo clean."
     }
   ]
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,11 +14,18 @@ edition = "2021"
 name = "openhome_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[profile.release]
+panic = "abort" # Strip expensive panic clean-up logic
+codegen-units = 1 # Compile crates one after another so the compiler can optimize better
+lto = true # Enables link to optimizations
+opt-level = "s" # Optimize for binary size
+strip = true # Remove debug symbols
+
 [build-dependencies]
-tauri-build = { version = "2"}
+tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2.1.1" }
+tauri = { version = "2.1.1", features = [] }
 tauri-plugin-shell = "2.2.0"
 serde = { version = "1.0.216", features = ["derive"] }
 serde_json = "1.0.134"


### PR DESCRIPTION
I added the recommended settings to the `cargo.toml` file: https://v1.tauri.app/v1/guides/building/app-size/#rust-build-time-optimizations

On my Windows machine this reduced the build size by ~15 mb.

Also I added a (windows only) task to the `tasks.json` file to help me clean the build.