### PR TITLE
fix: update pokemon species and forme when changed in game

### DIFF
--- a/src/pokemon/FileTypeSelect.tsx
+++ b/src/pokemon/FileTypeSelect.tsx
@@ -3,7 +3,7 @@ import { useContext, useMemo } from 'react'
 import { LGPE_TRANSFER_RESTRICTIONS } from 'src/consts/TransferRestrictions'
 import { supportsMon } from 'src/types/SAVTypes/util'
 import { isRestricted } from 'src/types/TransferRestrictions'
-import { PKMFormData, Styles } from 'src/types/types'
+import { PKMFormeRef, Styles } from 'src/types/types'
 import { filterUndefined } from 'src/util/Sort'
 import { AppInfoContext } from '../state/appInfo'
 
@@ -41,7 +41,7 @@ interface FileTypeSelectProps {
   baseFormat: string
   currentFormat: string
   color?: string
-  formData: PKMFormData
+  formData: PKMFormeRef
   onChange: (selectedFormat: string) => void
 }
 

--- a/src/types/pkm/OHPKM.ts
+++ b/src/types/pkm/OHPKM.ts
@@ -45,6 +45,7 @@ import {
 } from 'src/util/byteLogic'
 import { getHPGen3Onward, getLevelGen3Onward, getStatGen3Onward } from 'src/util/StatCalc'
 import { utf16BytesToString, utf16StringToBytes } from 'src/util/Strings/StringConverter'
+import { isEvolution } from '../../util/Lookup'
 import { PKMInterface, PluginPKMInterface } from '../interfaces'
 import schema from './OHPKM.json'
 import {
@@ -1626,6 +1627,14 @@ export class OHPKM implements PKMInterface {
     this.movePP = adjustMovePPBetweenFormats(this, other)
     this.movePPUps = other.movePPUps as [number, number, number, number]
 
+    if (this.dexNum !== other.dexNum && isEvolution(this, other)) {
+      this.dexNum = other.dexNum
+    }
+
+    if (this.dexNum === other.dexNum || isEvolution(this, other)) {
+      this.formeNum = other.formeNum
+    }
+
     if ('heldItemName' in other) {
       this.heldItemIndex = ItemFromString(other.heldItemName)
     }
@@ -1639,6 +1648,10 @@ export class OHPKM implements PKMInterface {
     if (other.evsG12) {
       this.evsG12 = other.evsG12
     }
+    if (other.hyperTraining) {
+      this.hyperTraining = other.hyperTraining
+    }
+
     this.ribbons = lodash.uniq([...this.ribbons, ...(other.ribbons ?? [])])
     if (other.contest) {
       this.contest = other.contest
@@ -1755,8 +1768,17 @@ export class OHPKM implements PKMInterface {
     if (other.teraTypeOverride !== undefined) {
       this.teraTypeOverride = other.teraTypeOverride
     }
+    if (other.trFlagsSwSh !== undefined) {
+      this.trFlagsSwSh = other.trFlagsSwSh
+    }
+    if (other.tmFlagsBDSP !== undefined) {
+      this.tmFlagsBDSP = other.tmFlagsBDSP
+    }
     if (other.tmFlagsSV !== undefined) {
       this.tmFlagsSV = other.tmFlagsSV
+    }
+    if (other.tmFlagsSVDLC !== undefined) {
+      this.tmFlagsSVDLC = other.tmFlagsSVDLC
     }
     if (other.obedienceLevel !== undefined) {
       this.obedienceLevel = other.obedienceLevel

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,4 +1,5 @@
 import { Either } from 'fp-ts/Either'
+import { PokemonData } from 'pokemon-species-data'
 import { CSSProperties } from 'react'
 import { PathData } from './SAVTypes/path'
 
@@ -54,46 +55,7 @@ export type SaveRefMap = { [key: string]: SaveRef }
 
 export type RegionalForme = 'Alola' | 'Galar' | 'Hisui' | 'Paldea'
 
-export type MonReference = { dexNumber: number; formeNumber: number }
-
-export type Forme = {
-  name: string
-  formeName: string
-  formeNumber: number
-  isBaseForme: boolean
-  isMega: boolean
-  isGMax: boolean
-  isBattleOnly: boolean
-  alias: string
-  types: Type[]
-  genderRatio: { M: number; F: number }
-  baseStats: {
-    hp: number
-    atk: number
-    def: number
-    spa: number
-    spd: number
-    spe: number
-  }
-  ability1: string
-  ability2?: string
-  abilityH?: string
-  height: number
-  weight: number
-  evos: MonReference[]
-  prevo?: MonReference
-  eggGroups: string[]
-  gen: number
-  regional?: RegionalForme
-  subLegendary: boolean
-  restrictedLegendary: boolean
-  ultraBeast: boolean
-  paradox: boolean
-  mythical: boolean
-  sprite: string
-  spriteIndex: [number, number]
-}
-
+export type Forme = (typeof PokemonData)[number]['formes'][number]
 export type Pokemon = {
   name: string
   nationalDex: number
@@ -152,7 +114,7 @@ export type LoadSaveResponse = {
   createdDate: Date
 }
 
-export interface PKMFormData {
+export interface PKMFormeRef {
   dexNum: number
   formeNum: number
 }

--- a/src/util/Lookup.ts
+++ b/src/util/Lookup.ts
@@ -1,8 +1,10 @@
 import { PK3, StatsPreSplit } from 'pokemon-files'
 import { isGameBoy } from 'pokemon-resources'
+import { PokemonData } from 'pokemon-species-data'
 import { PKMInterface } from '../types/interfaces'
 import { OHPKM } from '../types/pkm/OHPKM'
 import { getBaseMon } from '../types/pkm/util'
+import { Forme, PKMFormeRef } from '../types/types'
 import { bytesToString } from './byteLogic'
 import { gen12StringToUTF, utf16StringToGen12 } from './Strings/StringConverter'
 
@@ -63,4 +65,31 @@ export const getMonGen345Identifier = (mon: PKMInterface) => {
     console.error(error)
   }
   return undefined
+}
+
+export function getFormeData(dexNum: number, formeNum: number): Forme | undefined {
+  return PokemonData[dexNum]?.formes[formeNum]
+}
+
+export function isEvolution(prevo: PKMFormeRef, possibleEvo: PKMFormeRef): boolean {
+  const prevoForme = getFormeData(prevo.dexNum, prevo.formeNum)
+  const possibleEvoForme = getFormeData(possibleEvo.dexNum, possibleEvo.formeNum)
+
+  if (!prevoForme || !possibleEvoForme) return false
+
+  if (
+    prevoForme.evos.some(
+      (evo) => evo.dexNumber === possibleEvo.dexNum && evo.formeNumber === possibleEvo.formeNum
+    )
+  ) {
+    return true
+  }
+
+  for (const evo of prevoForme.evos) {
+    if (isEvolution(prevo, { dexNum: evo.dexNumber, formeNum: evo.formeNumber })) {
+      return true
+    }
+  }
+
+  return false
 }

--- a/src/util/__test__/lookup.test.ts
+++ b/src/util/__test__/lookup.test.ts
@@ -1,0 +1,51 @@
+import { MimeJr, MrMime, MrRime, Sylveon, Vaporeon } from 'pokemon-species-data'
+import { getFormeData, isEvolution } from '../Lookup'
+
+test('mr rime is evo of mime jr', () => {
+  expect(
+    isEvolution(
+      { dexNum: MimeJr.MimeJr.nationalDex, formeNum: 0 },
+      { dexNum: MrRime.MrRime.nationalDex, formeNum: 0 }
+    )
+  )
+})
+
+test('mr rime is evo of galarian mr mime', () => {
+  expect(
+    isEvolution(
+      { dexNum: MrMime.MrMime.nationalDex, formeNum: 1 },
+      { dexNum: MrRime.MrRime.nationalDex, formeNum: 0 }
+    )
+  )
+})
+
+test('mr rime is NOT evo of kantonian mr mime', () => {
+  expect(
+    !isEvolution(
+      { dexNum: MrMime.MrMime.nationalDex, formeNum: 0 },
+      { dexNum: MrRime.MrRime.nationalDex, formeNum: 0 }
+    )
+  )
+})
+
+test('mr rime is NOT evo of mr rime', () => {
+  expect(
+    !isEvolution(
+      { dexNum: MrRime.MrRime.nationalDex, formeNum: 0 },
+      { dexNum: MrRime.MrRime.nationalDex, formeNum: 0 }
+    )
+  )
+})
+
+test('vaporeon is NOT evo of sylveon', () => {
+  expect(
+    !isEvolution(
+      { dexNum: Sylveon.Sylveon.nationalDex, formeNum: 0 },
+      { dexNum: Vaporeon.Vaporeon.nationalDex, formeNum: 0 }
+    )
+  )
+})
+
+test('getFormeData returns undefined for invalid forme', () => {
+  expect(getFormeData(Sylveon.Sylveon.nationalDex, 100)).toBeUndefined()
+})


### PR DESCRIPTION
**Description**

- Fixed bug where Pokémon species was not updated in OpenHome when evolved after its first import to OpenHome
- Various other data is now updated correctly when changed in a game:
  - Pokémon forme number
  - TM/TR flags
  - Hyper training

**Issue**

Fixes #233 
