### PR TITLE
feat: new sort options

### DIFF
--- a/packages/pokemon-files/src/util/pkmInterface.ts
+++ b/packages/pokemon-files/src/util/pkmInterface.ts
@@ -40,7 +40,6 @@ export interface AllPKMFields {
   fieldEventFatigue2?: number
   flag2LA?: boolean
   formArgument?: number
-  formNum?: number
   formeNum: number
   fullness?: number
   gameOfOrigin: number


### PR DESCRIPTION
**Description**
Added the following sort options:
- Species Family
  - Sorts the Pokémon by the base evolution dex number, the Pokémon's dex number, and the Pokémon's forme number  in that order of precedence
- Shiny Status
- Held Item (alphabetical, items before non-items)
- Trainer
  - Alphabetical by trainer name, then trainer ID and secret ID in that order of precedence
- Poké Ball
  - By ball index number, which is roughly by order the ball was introduced

**Issue**

FIxes #278 
