### PR TITLE
fix: ability loss when ability has quote mark

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "fp-ts": "^2.16.11",
         "lodash": "^4.17.21",
         "pokemon-resources": "^1.0.12",
-        "pokemon-species-data": "^0.4.7",
+        "pokemon-species-data": "^0.4.9",
         "prando": "^6.0.1",
         "react": "^19.1.0",
         "react-chartjs-2": "^5.3.0",
@@ -9366,9 +9366,9 @@
       "license": "GPL-3.0-only"
     },
     "node_modules/pokemon-species-data": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/pokemon-species-data/-/pokemon-species-data-0.4.7.tgz",
-      "integrity": "sha512-BQ88T4JOn2Uli7qI1a8fVRweyla4wfeScRPRe8CRCoPbKhtuJL9WjJZps8+YZO33lkD9sOJFz3+ZV/9D9V+GOw==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/pokemon-species-data/-/pokemon-species-data-0.4.9.tgz",
+      "integrity": "sha512-l6Eh5ASMraVO43O3sHyuX+LaiMw5Grvrfnxre7aDEmApGBfCT4iNt4xZYKdIU6xqafZrb6VnyG0bSJti0CmBfQ==",
       "license": "GPL-3.0-only",
       "dependencies": {
         "pokemon-resources": "^1.0.12"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "fp-ts": "^2.16.11",
     "lodash": "^4.17.21",
     "pokemon-resources": "^1.0.12",
-    "pokemon-species-data": "^0.4.7",
+    "pokemon-species-data": "^0.4.9",
     "prando": "^6.0.1",
     "react": "^19.1.0",
     "react-chartjs-2": "^5.3.0",

--- a/src/types/pkm/OHPKM.ts
+++ b/src/types/pkm/OHPKM.ts
@@ -1574,6 +1574,12 @@ export class OHPKM implements PKMInterface {
       errorsFound = true
     }
 
+    // Fix ability bug from pre-1.5.0 (affected Mind's Eye and Dragon's Maw)
+    if (this.abilityIndex === 0) {
+      this.ability = getAbilityFromNumber(this.dexNum, this.formeNum, this.abilityNum)
+      this.abilityIndex = AbilityFromString(this.ability)
+    }
+
     const genderRatio = PokemonData[this.dexNum].formes[this.formeNum].genderRatio
 
     if (this.gender === 2 && (genderRatio.male !== 0 || genderRatio.female !== 0)) {


### PR DESCRIPTION
**Description**

Due to how Abilities are represented and converted (using TypeScript enums and string representation), the abilities with a quote mark were lost when converting to OHPKM (Mind's Eye and Dragon's Maw). This update pulls in the fix from `pokemon-species-data`

**Issue**

Fixes #297 
