### PR TITLE
Fix the save disambiguation

### DIFF
--- a/src/saves/SavesModal.tsx
+++ b/src/saves/SavesModal.tsx
@@ -122,7 +122,9 @@ function useOpenSaveHandler(onClose?: () => void) {
             if (filePath && fileBytes) {
               let saveTypes = getSaveTypes(fileBytes, getEnabledSaveTypes())
 
-              if (saveTypes.some(isSpecialType)) {
+              if (saveTypes.length > 1) {
+                setTentativeSaveData({ possibleSaveTypes: saveTypes, filePath, fileBytes })
+              } else if (saveTypes.some(isSpecialType)) {
                 const options = getSpecialDisambiguationOptions(getEnabledSaveTypes)
 
                 if (options.length > 0) {

--- a/src/saves/SavesModal.tsx
+++ b/src/saves/SavesModal.tsx
@@ -32,13 +32,6 @@ type AmbiguousOpenState = {
   fileBytes: Uint8Array
 }
 
-// If any detected type name matches these, force the disambiguation UI.
-const SPECIAL_DISAMBIG_NAMES = ['unbound', 'radical red'] as const
-const isSpecialType = (t: SAVClass) =>
-  !!t?.saveTypeName && SPECIAL_DISAMBIG_NAMES.some((n) => t.saveTypeName.toLowerCase().includes(n))
-const getSpecialDisambiguationOptions = (getEnabled: () => SAVClass[]) =>
-  getEnabled().filter(isSpecialType)
-
 const debouncedUpdateCardSize = debounce(
   (size: number, dispatch: React.Dispatch<AppInfoAction>) => {
     dispatch({ type: 'set_icon_size', payload: size })
@@ -121,15 +114,6 @@ function useOpenSaveHandler(onClose?: () => void) {
             filePath = path
             if (filePath && fileBytes) {
               let saveTypes = getSaveTypes(fileBytes, getEnabledSaveTypes())
-
-              // if (saveTypes.some(isSpecialType)) {
-              //   const options = getSpecialDisambiguationOptions(getEnabledSaveTypes)
-
-              //   if (options.length > 0) {
-              //     setTentativeSaveData({ possibleSaveTypes: options, filePath, fileBytes })
-              //     return
-              //   }
-              // }
 
               if (saveTypes.length === 1) {
                 await buildAndOpenSave(saveTypes[0], filePath, fileBytes)

--- a/src/saves/SavesModal.tsx
+++ b/src/saves/SavesModal.tsx
@@ -122,16 +122,14 @@ function useOpenSaveHandler(onClose?: () => void) {
             if (filePath && fileBytes) {
               let saveTypes = getSaveTypes(fileBytes, getEnabledSaveTypes())
 
-              if (saveTypes.length > 1) {
-                setTentativeSaveData({ possibleSaveTypes: saveTypes, filePath, fileBytes })
-              } else if (saveTypes.some(isSpecialType)) {
-                const options = getSpecialDisambiguationOptions(getEnabledSaveTypes)
+              // if (saveTypes.some(isSpecialType)) {
+              //   const options = getSpecialDisambiguationOptions(getEnabledSaveTypes)
 
-                if (options.length > 0) {
-                  setTentativeSaveData({ possibleSaveTypes: options, filePath, fileBytes })
-                  return
-                }
-              }
+              //   if (options.length > 0) {
+              //     setTentativeSaveData({ possibleSaveTypes: options, filePath, fileBytes })
+              //     return
+              //   }
+              // }
 
               if (saveTypes.length === 1) {
                 await buildAndOpenSave(saveTypes[0], filePath, fileBytes)

--- a/src/types/SAVTypes/radicalred/G3RRSAV.ts
+++ b/src/types/SAVTypes/radicalred/G3RRSAV.ts
@@ -36,12 +36,6 @@ export class G3RRSAV extends G3CFRUSAV<PK3RR> implements PluginSAV<PK3RR> {
     const firstSectionBytesIndex = findFirstSectionOffset(bytes)
     const firstSectionBytes = bytes.slice(firstSectionBytesIndex, firstSectionBytesIndex + 0x1000)
 
-    const signature = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
-
-    console.info('Checking Radical Red save', { signature })
-
-    if (signature === 0x08012025) return true
-
     const gameCode = bytesToUint32LittleEndian(firstSectionBytes, 0xac)
 
     if (gameCode !== 1) return false

--- a/src/types/SAVTypes/radicalred/G3RRSAV.ts
+++ b/src/types/SAVTypes/radicalred/G3RRSAV.ts
@@ -36,6 +36,12 @@ export class G3RRSAV extends G3CFRUSAV<PK3RR> implements PluginSAV<PK3RR> {
     const firstSectionBytesIndex = findFirstSectionOffset(bytes)
     const firstSectionBytes = bytes.slice(firstSectionBytesIndex, firstSectionBytesIndex + 0x1000)
 
+    const signature = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
+
+    console.info('Checking Radical Red save', { signature })
+
+    if (signature === 0x08012025) return true
+
     const gameCode = bytesToUint32LittleEndian(firstSectionBytes, 0xac)
 
     if (gameCode !== 1) return false

--- a/src/types/SAVTypes/unbound/G3UBSAV.ts
+++ b/src/types/SAVTypes/unbound/G3UBSAV.ts
@@ -47,17 +47,9 @@ export class G3UBSAV extends G3CFRUSAV<PK3UB> implements PluginSAV<PK3UB> {
 
     const signature = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
 
-    console.info('Checking Unbound save', { signature })
-
     // from unbound cloud
     // https://github.com/Skeli789/Unbound-Cloud/blob/a5d966b74b865f51fef608e19ca63e0e51593f5e/server/src/Defines.py#L25C1-L26C1
-    if (signature === 0x01122000 || signature === 0x01121999 || signature === 0x01121998) {
-      return true
-    }
-
-    const gameCode = bytesToUint32LittleEndian(firstSectionBytes, 0xac)
-
-    return gameCode === 0xffffffff
+    return signature === 0x01122000 || signature === 0x01121999 || signature === 0x01121998
   }
 
   gameColor(): string {

--- a/src/types/SAVTypes/unbound/G3UBSAV.ts
+++ b/src/types/SAVTypes/unbound/G3UBSAV.ts
@@ -45,13 +45,13 @@ export class G3UBSAV extends G3CFRUSAV<PK3UB> implements PluginSAV<PK3UB> {
     const firstSectionBytesIndex = findFirstSectionOffset(bytes)
     const firstSectionBytes = bytes.slice(firstSectionBytesIndex, firstSectionBytesIndex + 0x1000)
 
-    const securityKey = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
+    const signature = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
 
-    console.info('Checking Unbound save', { securityKey })
+    console.info('Checking Unbound save', { signature })
 
     // from unbound cloud
     // https://github.com/Skeli789/Unbound-Cloud/blob/a5d966b74b865f51fef608e19ca63e0e51593f5e/server/src/Defines.py#L25C1-L26C1
-    if (securityKey === 0x01122000 || securityKey === 0x01121999 || securityKey === 0x01121998) {
+    if (signature === 0x01122000 || signature === 0x01121999 || signature === 0x01121998) {
       return true
     }
 

--- a/src/types/SAVTypes/unbound/G3UBSAV.ts
+++ b/src/types/SAVTypes/unbound/G3UBSAV.ts
@@ -45,6 +45,16 @@ export class G3UBSAV extends G3CFRUSAV<PK3UB> implements PluginSAV<PK3UB> {
     const firstSectionBytesIndex = findFirstSectionOffset(bytes)
     const firstSectionBytes = bytes.slice(firstSectionBytesIndex, firstSectionBytesIndex + 0x1000)
 
+    const securityKey = bytesToUint32LittleEndian(firstSectionBytes, 0x0ff8)
+
+    console.info('Checking Unbound save', { securityKey })
+
+    // from unbound cloud
+    // https://github.com/Skeli789/Unbound-Cloud/blob/a5d966b74b865f51fef608e19ca63e0e51593f5e/server/src/Defines.py#L25C1-L26C1
+    if (securityKey === 0x01122000 || securityKey === 0x01121999 || securityKey === 0x01121998) {
+      return true
+    }
+
     const gameCode = bytesToUint32LittleEndian(firstSectionBytes, 0xac)
 
     return gameCode === 0xffffffff


### PR DESCRIPTION
This fixes a bug introduced in #285 with the current method where Firered Saves are being mistaken as Radical Red saves. I think it's clear that more work needs to be done to distinguish between legit gen 3 saves and gen 3 rom hack saves. But this method will work for now.