### PR TITLE
Remove RUSTFLAGS from wasm build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "dev": "npm run wasm && vite",
     "tauri": "tauri",
     "test": "vitest run",
-    "wasm": "RUSTFLAGS='--cfg getrandom_backend=\"wasm_js\"' wasm-pack build ./pkm_rs_resources --target web -- --features wasm",
+    "wasm": "wasm-pack build ./pkm_rs_resources --target web -- --features wasm",
     "precommit": "prettier --write . && eslint src --report-unused-disable-directives -c eslint.config.mjs --fix"
   },
   "dependencies": {


### PR DESCRIPTION
Unnecessary and prevent compilation on Windows