### PR TITLE
fix: expand sv save detection file size range

### DIFF
--- a/src/types/SAVTypes/Gen89/SVSAV.ts
+++ b/src/types/SAVTypes/Gen89/SVSAV.ts
@@ -13,7 +13,7 @@ import { SCBlock, SCObjectBlock } from './SwishCrypto/SCBlock'
 import { SwishCrypto } from './SwishCrypto/SwishCrypto'
 
 const SAVE_SIZE_BYTES_MIN = 0x31626f
-const SAVE_SIZE_BYTES_MAX = 0x43b000
+const SAVE_SIZE_BYTES_MAX = 0x43c000
 
 export type SV_SAVE_REVISION = 'Base Game' | 'Teal Mask' | 'Indigo Disk'
 


### PR DESCRIPTION
**Description**

- Larger save files are now accepted as Scarlet/Violet

**Issue**

Fixes #338 
