### PR TITLE
[FIX] incorrect ho-oh index for radical red

### DIFF
--- a/src/core/save/radicalred/conversion/RadicalRedSpeciesMap.ts
+++ b/src/core/save/radicalred/conversion/RadicalRedSpeciesMap.ts
@@ -1003,7 +1003,7 @@ export const RadicalRedToNationalDexMap: Record<string, GameToNationalDexEntry |
   },
   '250': {
     NationalDexIndex: 250,
-    FormIndex: 250,
+    FormIndex: 0,
   },
   '251': {
     NationalDexIndex: 251,


### PR DESCRIPTION
**Description**

Fixed the erroneous Ho-Oh forme number (250) in the Radical Red lookup match

**Issue**

Fixes #441 
