### PR TITLE
[FIX] fix broken move filter logic + add regression tests

### DIFF
--- a/packages/pokemon-files/src/util/util.ts
+++ b/packages/pokemon-files/src/util/util.ts
@@ -14,6 +14,7 @@ import {
   PkmFormat,
   PkmFormats,
 } from '@pkm-rs/pkg'
+import { filterUndefined } from 'src/core/util/sort'
 import { PKMInterface } from '../../../../src/core/pkm/interfaces'
 import { AllPKMFields, FourMoves } from './pkmInterface'
 
@@ -240,13 +241,11 @@ export class MoveFilter<P extends PKMInterface> {
   }
 
   private filterByMoves(mon: AllPKMFields, toFilter: FourMoves): FourMoves {
-    const filtered: FourMoves = [0, 0, 0, 0]
-    for (let i = 0; i < 4; i++) {
-      if (this.moveIsAllowed(mon.moves[i])) {
-        filtered[i] = toFilter[i]
-      }
-    }
-    return filtered
+    const filtered = mon.moves
+      .map((move, i) => (this.moveIsAllowed(move) ? toFilter[i] : undefined))
+      .filter(filterUndefined)
+
+    return [filtered[0] ?? 0, filtered[1] ?? 0, filtered[2] ?? 0, filtered[3] ?? 0]
   }
 
   private hasAtLeastOneAllowedMove(mon: AllPKMFields) {
@@ -262,9 +261,15 @@ export class MoveFilter<P extends PKMInterface> {
       )
       if (levelUpLearnset) {
         const fromLevelup: FourMoves = [0, 0, 0, 0]
-        levelUpLearnset.slice(-4).forEach((move, i) => {
-          fromLevelup[i] = move.move_id
-        })
+        levelUpLearnset
+          .filter(
+            (move) =>
+              move.is_evolution || (move.level !== undefined && move.level <= mon.getLevel())
+          )
+          .slice(-4)
+          .forEach((move, i) => {
+            fromLevelup[i] = move.move_id
+          })
         return fromLevelup
       }
     }

--- a/src/core/pkm/__test__/OhpkmV2.test.ts
+++ b/src/core/pkm/__test__/OhpkmV2.test.ts
@@ -1,6 +1,6 @@
 import PB8LUMI from '@openhome-core/save/luminescentplatinum/PB8LUMI'
 import { ConvertStrategies, ConvertStrategy, ExtraFormIndex, OriginGame } from '@pkm-rs/pkg'
-import { PA8, PK3, PK4, PK7, PK8 } from '@pokemon-files/pkm'
+import { PA8, PK3, PK4, PK7, PK8, PK9 } from '@pokemon-files/pkm'
 import { HyperTrainStats, Stats } from '@pokemon-files/util'
 import { getFormatLocationString } from '@pokemon-resources/locations'
 import fs from 'fs'
@@ -178,6 +178,54 @@ function sanitizeWasmHyperTraining(fromWasm: HyperTrainStats): HyperTrainStats {
     spe: fromWasm.spe,
   }
 }
+
+describe('move filter', () => {
+  const HYDRO_PUMP = 56
+  const RAIN_DANCE = 240
+  const AQUA_TAIL = 401
+  const DRAGON_DANCE = 349
+
+  const FOCUS_ENERGY = 116
+  const CRUNCH = 242
+  const HURRICANE = 542
+
+  test('non-filtered moves have no gaps', () => {
+    const ohpkm = OHPKM.defaultWithSpecies(NationalDex.Gyarados, 0)
+    ohpkm.moves = [AQUA_TAIL, RAIN_DANCE, HYDRO_PUMP, DRAGON_DANCE]
+    ohpkm.movePP = [10, 5, 5, 20]
+    ohpkm.movePPUps = [1, 2, 3, 1]
+
+    const pa8 = PA8.fromOhpkm(ohpkm, ConvertStrategies.getDefault())
+    expect(pa8.moves).toEqual([AQUA_TAIL, HYDRO_PUMP, 0, 0])
+    expect(pa8.movePP).toEqual([10, 5, 0, 0])
+    expect(pa8.movePPUps).toEqual([1, 3, 0, 0])
+  })
+
+  test('if no moves are compatible, use level-up moves', () => {
+    const ohpkm = OHPKM.defaultWithSpecies(NationalDex.Gyarados, 0)
+    ohpkm.exp = 80000 // level 40 (slow level-up group)
+    ohpkm.moves = [RAIN_DANCE, DRAGON_DANCE, 0, 0]
+    ohpkm.movePP = [5, 20, 0, 0]
+    ohpkm.movePPUps = [1, 2, 0, 0]
+
+    const pa8 = PA8.fromOhpkm(ohpkm, ConvertStrategies.getDefault())
+    expect(pa8.moves).toEqual([FOCUS_ENERGY, CRUNCH, AQUA_TAIL, HURRICANE])
+    expect(pa8.movePP).toEqual([20, 10, 10, 5])
+    expect(pa8.movePPUps).toEqual([0, 0, 0, 0])
+  })
+
+  test('no changes made if all moves are compatible', () => {
+    const ohpkm = OHPKM.defaultWithSpecies(NationalDex.Gyarados, 0)
+    ohpkm.moves = [AQUA_TAIL, RAIN_DANCE, HYDRO_PUMP, DRAGON_DANCE]
+    ohpkm.movePP = [10, 5, 5, 20]
+    ohpkm.movePPUps = [1, 2, 3, 1]
+
+    const pk9 = PK9.fromOhpkm(ohpkm, ConvertStrategies.getDefault())
+    expect(pk9.moves).toEqual([AQUA_TAIL, RAIN_DANCE, HYDRO_PUMP, DRAGON_DANCE])
+    expect(pk9.movePP).toEqual([10, 5, 5, 20])
+    expect(pk9.movePPUps).toEqual([1, 2, 3, 1])
+  })
+})
 
 describe('OHPKM conversion strategies', () => {
   test('hyper training conversion strategy', () => {


### PR DESCRIPTION
**Description**

- Fixes bug in move filter logic
  - Pokémon moved to Legends Arceus will no longer appear as eggs if they had a mix of compatible and incompatible moves

**Issue**

Fixes #596 
