### PR TITLE
[FEAT] OHPKM tracked timestamp

### DIFF
--- a/pkm_rs/src/gen7_alola/pk7.rs
+++ b/pkm_rs/src/gen7_alola/pk7.rs
@@ -410,7 +410,8 @@ impl Pk7 {
         bytes: Vec<u8>,
         strategy: ConvertStrategy,
     ) -> core::result::Result<Pk7, JsValue> {
-        let ohpkm = OhpkmV2::from_bytes(&bytes).map_err(|e| JsValue::from_str(&e.to_string()))?;
+        let ohpkm =
+            OhpkmV2::from_bytes(&bytes, None).map_err(|e| JsValue::from_str(&e.to_string()))?;
         Ok(Pk7::from_ohpkm(&ohpkm, strategy))
     }
 

--- a/pkm_rs/src/ohpkm/v1.rs
+++ b/pkm_rs/src/ohpkm/v1.rs
@@ -1,12 +1,15 @@
+use std::num::NonZeroU64;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use crate::result::{Error, Result};
-use crate::traits::{HasSpeciesAndForm, IsShiny4096, PkmBytes};
+use crate::traits::{IsShiny4096, PkmBytes};
 use crate::util;
 
 use pkm_rs_resources::ball::Ball;
 use pkm_rs_resources::moves::MoveIndex;
 use pkm_rs_resources::natures::NatureIndex;
 use pkm_rs_resources::ribbons::{ModernRibbon, OpenHomeRibbonSet};
-use pkm_rs_resources::species::{FormMetadata, SpeciesAndForm, SpeciesMetadata};
+use pkm_rs_resources::species::SpeciesAndForm;
 
 use pkm_rs_types::strings::SizedUtf16String;
 use pkm_rs_types::{ContestStats, Language, Stats8, Stats16Le, StatsPreSplit};
@@ -15,16 +18,8 @@ use pkm_rs_types::{Geolocations, HyperTraining, MarkingsSixShapesColors};
 
 use serde::Serialize;
 
-#[cfg(feature = "wasm")]
-use wasm_bindgen::prelude::*;
-
-#[cfg(feature = "randomize")]
-use pkm_rs_types::randomize::Randomize;
-
 const MIN_SIZE: usize = 420;
 
-#[cfg_attr(feature = "wasm", wasm_bindgen)]
-#[cfg_attr(feature = "randomize", derive(Randomize))]
 #[derive(Debug, Default, Serialize, Clone, Copy, IsShiny4096)]
 pub struct OhpkmV1 {
     pub encryption_constant: u32,
@@ -53,22 +48,16 @@ pub struct OhpkmV1 {
     pub pokerus_byte: u8,
     pub contest_memory_count: u8,
     pub battle_memory_count: u8,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub ribbons: OpenHomeRibbonSet<16>,
     pub sociability: u32,
     pub height_scalar: u8,
     pub weight_scalar: u8,
     pub scale: u8,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub moves: [MoveIndex; 4],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub move_pp: [u8; 4],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub nickname: SizedUtf16String<26>,
     pub avs: Stats16Le,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub move_pp_ups: [u8; 4],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub relearn_moves: [MoveIndex; 4],
     pub ivs: Stats8,
     pub is_egg: bool,
@@ -79,7 +68,6 @@ pub struct OhpkmV1 {
     pub unknown_a0: u32,
     pub gvs: Stats8,
     pub dvs: StatsPreSplit,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub handler_name: SizedUtf16String<26>,
     pub handler_language: u8,
     pub is_current_handler: bool,
@@ -104,7 +92,6 @@ pub struct OhpkmV1 {
     pub enjoyment: u8,
     pub game_of_origin: OriginGame,
     pub game_of_origin_battle: Option<OriginGame>,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub plugin_origin: SizedUtf16String<32>,
     pub country: u8,
     pub region: u8,
@@ -116,7 +103,7 @@ pub struct OhpkmV1 {
     pub geolocations: Geolocations,
     pub encounter_type: u8,
     pub performance: u8,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
+
     pub trainer_name: SizedUtf16String<26>,
     pub trainer_friendship: u8,
     pub trainer_memory: TrainerMemory,
@@ -130,23 +117,17 @@ pub struct OhpkmV1 {
     pub hyper_training: HyperTraining,
     pub trainer_gender: Gender,
     pub obedience_level: u8,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub home_tracker: [u8; 8],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub tr_flags_swsh: [u8; 14],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub tm_flags_bdsp: [u8; 14],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub move_flags_la: [u8; 14],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub tutor_flags_la: [u8; 8],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub master_flags_la: [u8; 8],
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub tm_flags_sv: [u8; 22],
     pub evs_g12: StatsPreSplit,
-    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub tm_flags_sv_dlc: [u8; 13],
+
+    pub file_timestamp_seconds: Option<NonZeroU64>,
 }
 
 impl OhpkmV1 {
@@ -308,7 +289,20 @@ impl OhpkmV1 {
             } else {
                 SizedUtf16String::<32>::default()
             },
+            file_timestamp_seconds: None,
         };
+        Ok(mon)
+    }
+
+    pub fn from_bytes_and_timestamp(bytes: &[u8], timestamp: SystemTime) -> Result<Self> {
+        let mut mon = OhpkmV1::from_bytes(bytes)?;
+        mon.file_timestamp_seconds = timestamp
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .as_ref()
+            .map(Duration::as_secs)
+            .and_then(NonZeroU64::new);
+
         Ok(mon)
     }
 }
@@ -489,32 +483,6 @@ impl PkmBytes for OhpkmV1 {
     }
 
     fn to_party_bytes(&self) -> Vec<u8> {
-        self.to_box_bytes()
-    }
-}
-
-impl HasSpeciesAndForm for OhpkmV1 {
-    fn get_species_metadata(&self) -> &'static SpeciesMetadata {
-        self.species_and_form.get_species_metadata()
-    }
-
-    fn get_forme_metadata(&self) -> &'static FormMetadata {
-        self.species_and_form.get_forme_metadata()
-    }
-
-    fn calculate_level(&self) -> u8 {
-        self.get_species_metadata()
-            .level_up_type
-            .calculate_level(self.exp)
-    }
-}
-
-#[cfg(feature = "wasm")]
-#[wasm_bindgen]
-#[allow(clippy::missing_const_for_fn)]
-impl OhpkmV1 {
-    #[wasm_bindgen(js_name = "toBytes")]
-    pub fn to_bytes_wasm(&self) -> Vec<u8> {
         self.to_box_bytes()
     }
 }

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -3382,6 +3382,11 @@ impl OhpkmV2 {
         self.get_started_tracking_seconds().map(NonZeroU64::get)
     }
 
+    #[wasm_bindgen(setter = startedTrackingSeconds)]
+    pub fn set_started_tracking_seconds_js(&mut self, seconds: u64) {
+        self.main_data.started_tracking_seconds = NonZeroU64::new(seconds)
+    }
+
     // Original Data
     #[wasm_bindgen(getter = originalData)]
     pub fn original_data(&self) -> Option<OriginalDataJs> {

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU64;
+
 use super::sectioned_data::{DataSection, SectionTag, SectionedData};
 use super::v2_sections::{
     BdspData, GameboyData, Gen45Data, Gen67Data, LegendsArceusData, MainDataV2, MostRecentSave,
@@ -231,7 +233,6 @@ pub struct OhpkmV2 {
 }
 
 impl OhpkmV2 {
-    #[cfg(feature = "wasm")]
     pub fn openhome_id(&self) -> String {
         self.main_data.openhome_id()
     }
@@ -1491,7 +1492,7 @@ impl OhpkmV2 {
         }
     }
 
-    // Notes
+    // Other metadata
 
     pub fn notes(&self) -> Option<String> {
         Some(self.notes.clone()?.0)
@@ -1504,10 +1505,20 @@ impl OhpkmV2 {
         }
     }
 
-    // Most Recent save
-
     pub fn most_recent_save(&self) -> Option<MostRecentSave> {
         self.most_recent_save.clone()
+    }
+
+    pub fn get_started_tracking_seconds(&self) -> Option<NonZeroU64> {
+        self.main_data.started_tracking_seconds
+    }
+
+    pub fn set_started_tracking_if_missing(
+        &mut self,
+        started_tracking_seconds: Option<NonZeroU64>,
+    ) {
+        self.main_data
+            .with_timestamp_if_missing(started_tracking_seconds);
     }
 
     // Calculated
@@ -1575,7 +1586,7 @@ impl OhpkmV2 {
         })
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+    pub fn from_bytes(bytes: &[u8], file_created_seconds: Option<NonZeroU64>) -> Result<Self> {
         let sectioned_data = SectionedData::<OhpkmSectionTag>::from_bytes(bytes)?;
 
         if sectioned_data.magic_number != MAGIC_NUMBER {
@@ -1596,8 +1607,9 @@ impl OhpkmV2 {
         };
 
         let result = Self {
-            main_data: MainDataV2::extract_from(&sectioned_data)?
-                .ok_or(Error::other("Main data not present in OHPKM V2 file"))?,
+            main_data: *MainDataV2::extract_from(&sectioned_data)?
+                .ok_or(Error::other("Main data not present in OHPKM V2 file"))?
+                .with_timestamp_if_missing(file_created_seconds),
             gameboy_data: GameboyData::extract_from(&sectioned_data)?,
             gen45_data: Gen45Data::extract_from(&sectioned_data)?,
             gen67_data: Gen67Data::extract_from(&sectioned_data)?,
@@ -1784,7 +1796,7 @@ impl OhpkmV2 {
     #[wasm_bindgen(constructor)]
     pub fn from_byte_vector(bytes: &[u8]) -> JsResult<Self> {
         if !bytes.is_empty() {
-            Self::from_bytes(bytes).map_err(|e| JsValue::from_str(&e.to_string()))
+            Self::from_bytes(bytes, None).map_err(|e| JsValue::from_str(&e.to_string()))
         } else {
             Ok(Self::default())
         }
@@ -1793,7 +1805,7 @@ impl OhpkmV2 {
     #[wasm_bindgen(js_name = "fromByteVectorFixingErrors")]
     pub fn from_byte_vector_fixing_errors(bytes: &[u8]) -> JsResult<Self> {
         Ok(if !bytes.is_empty() {
-            Self::from_bytes(bytes)?
+            Self::from_bytes(bytes, None)?
         } else {
             Self::default()
         })
@@ -3365,6 +3377,11 @@ impl OhpkmV2 {
         self.most_recent_save.clone()
     }
 
+    #[wasm_bindgen(getter = startedTrackingSeconds)]
+    pub fn started_tracking_seconds_js(&self) -> Option<u64> {
+        self.get_started_tracking_seconds().map(NonZeroU64::get)
+    }
+
     // Original Data
     #[wasm_bindgen(getter = originalData)]
     pub fn original_data(&self) -> Option<OriginalDataJs> {
@@ -3499,7 +3516,7 @@ impl PkmBytes for OhpkmV2 {
     const PARTY_SIZE: usize = 0;
 
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        match Self::from_bytes(bytes) {
+        match Self::from_bytes(bytes, None) {
             Ok(ohpkm) => Ok(ohpkm),
             Err(err) => Err(Error::other(&err.to_string())),
         }
@@ -3561,7 +3578,10 @@ impl IsShiny for OhpkmV2 {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{
+        path::Path,
+        time::{Duration, UNIX_EPOCH},
+    };
 
     use super::*;
     #[test]
@@ -3578,7 +3598,17 @@ mod tests {
                 continue;
             }
             let data = std::fs::read(entry.path()).unwrap();
-            OhpkmV2::from_bytes(&data).map_err(|e| {
+
+            let file_created_seconds = entry
+                .metadata()
+                .ok()
+                .and_then(|m| m.created().or(m.modified()).ok())
+                .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                .as_ref()
+                .map(Duration::as_secs)
+                .and_then(NonZeroU64::new);
+
+            OhpkmV2::from_bytes(&data, file_created_seconds).map_err(|e| {
                 format!(
                     "failed to build ohpkm file {}: {e}",
                     entry.path().file_name().unwrap().to_string_lossy()

--- a/pkm_rs/src/ohpkm/v2_sections.rs
+++ b/pkm_rs/src/ohpkm/v2_sections.rs
@@ -704,6 +704,17 @@ impl DataSection for MainDataV2 {
 }
 
 #[cfg(feature = "randomize")]
+fn current_time_unix_seconds() -> NonZeroU64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .as_ref()
+        .map(Duration::as_secs)
+        .and_then(NonZeroU64::new)
+        .expect("current time is after the unix epoch")
+}
+
+#[cfg(feature = "randomize")]
 impl Randomize for MainDataV2 {
     fn randomized<R: rand::Rng>(rng: &mut R) -> Self {
         let species_and_form = SpeciesAndForm::randomized(rng);

--- a/pkm_rs/src/ohpkm/v2_sections.rs
+++ b/pkm_rs/src/ohpkm/v2_sections.rs
@@ -136,16 +136,6 @@ pub struct MainDataV2 {
 const NIDORAN_F: NatDexIndex = unsafe { NatDexIndex::new_unchecked(29) };
 const NIDORAN_M: NatDexIndex = unsafe { NatDexIndex::new_unchecked(32) };
 
-fn current_time_unix_seconds() -> NonZeroU64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .ok()
-        .as_ref()
-        .map(Duration::as_secs)
-        .and_then(NonZeroU64::new)
-        .expect("current time is after the unix epoch")
-}
-
 impl MainDataV2 {
     pub fn new(national_dex: u16, form_index: u16) -> Result<Self> {
         let species_and_form = SpeciesAndForm::new(national_dex, form_index)?;

--- a/pkm_rs/src/ohpkm/v2_sections.rs
+++ b/pkm_rs/src/ohpkm/v2_sections.rs
@@ -25,14 +25,15 @@ use pkm_rs_types::{FlagSet, Geolocations, HyperTraining, MarkingsSixShapesColors
 use pkm_rs_types::{Gender, OriginGame, PokeDate, ShinyLeaves, TrainerMemory};
 #[cfg(feature = "randomize")]
 use rand::RngExt;
+use serde::Deserialize;
 use serde::Serialize;
 use std::num::{NonZeroU16, NonZeroU64};
+
+#[cfg(feature = "randomize")]
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "randomize")]
 use pkm_rs_types::randomize::Randomize;
-
-use serde::Deserialize;
 
 pub mod pkm_bytes;
 

--- a/pkm_rs/src/ohpkm/v2_sections.rs
+++ b/pkm_rs/src/ohpkm/v2_sections.rs
@@ -23,8 +23,11 @@ use pkm_rs_types::{
 };
 use pkm_rs_types::{FlagSet, Geolocations, HyperTraining, MarkingsSixShapesColors, TeraType};
 use pkm_rs_types::{Gender, OriginGame, PokeDate, ShinyLeaves, TrainerMemory};
+#[cfg(feature = "randomize")]
+use rand::RngExt;
 use serde::Serialize;
-use std::num::NonZeroU16;
+use std::num::{NonZeroU16, NonZeroU64};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(feature = "randomize")]
 use pkm_rs_types::randomize::Randomize;
@@ -126,10 +129,22 @@ pub struct MainDataV2 {
     pub home_tracker: [u8; 8],
     #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
     pub display_color_rgb: Option<[u8; 3]>,
+    #[cfg_attr(feature = "wasm", wasm_bindgen(skip))]
+    pub started_tracking_seconds: Option<NonZeroU64>,
 }
 
 const NIDORAN_F: NatDexIndex = unsafe { NatDexIndex::new_unchecked(29) };
 const NIDORAN_M: NatDexIndex = unsafe { NatDexIndex::new_unchecked(32) };
+
+fn current_time_unix_seconds() -> NonZeroU64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .as_ref()
+        .map(Duration::as_secs)
+        .and_then(NonZeroU64::new)
+        .expect("current time is after the unix epoch")
+}
 
 impl MainDataV2 {
     pub fn new(national_dex: u16, form_index: u16) -> Result<Self> {
@@ -142,6 +157,7 @@ impl MainDataV2 {
             ..Default::default()
         })
     }
+
     pub fn from_v1(old: super::v1::OhpkmV1) -> Self {
         MainDataV2 {
             encryption_constant: old.encryption_constant,
@@ -215,6 +231,7 @@ impl MainDataV2 {
             obedience_level: old.obedience_level,
             home_tracker: old.home_tracker,
             display_color_rgb: None,
+            started_tracking_seconds: old.file_timestamp_seconds,
         }
     }
 
@@ -222,7 +239,6 @@ impl MainDataV2 {
         self.species_and_form.get_ndex()
     }
 
-    #[cfg(feature = "wasm")]
     pub fn openhome_id(&self) -> String {
         let base_mon = self.species_and_form.get_base_evolution();
         format!(
@@ -233,6 +249,17 @@ impl MainDataV2 {
             self.personality_value,
             self.game_of_origin as u8
         )
+    }
+
+    pub fn with_timestamp_if_missing(
+        &mut self,
+        started_tracking_seconds: Option<NonZeroU64>,
+    ) -> &mut Self {
+        if self.started_tracking_seconds.is_none() {
+            self.started_tracking_seconds = started_tracking_seconds;
+        }
+
+        self
     }
 
     pub fn nickname_matches_species_ignore_case(&self) -> bool {
@@ -525,13 +552,9 @@ impl DataSection for MainDataV2 {
                 text_variable: u16::from_le_bytes(bytes[220..222].try_into().unwrap()),
             },
             handler_affection: bytes[222],
-            // super_training_flags: u32::from_le_bytes(bytes[223..227].try_into().unwrap()),
-            // super_training_dist_flags: bytes[227],
-            // secret_super_training_unlocked: util::get_flag(bytes, 228, 0),
-            // secret_super_training_complete: util::get_flag(bytes, 228, 1),
-            // training_bag_hits: bytes[229],
-            // training_bag: bytes[230],
-            // 231..235
+            started_tracking_seconds: NonZeroU64::new(u64::from_le_bytes(
+                bytes[223..231].try_into().unwrap(),
+            )),
             // poke_star_fame: bytes[232],
             obedience_level: bytes[233],
             // shiny_leaves: bytes[234] & 0x3f,
@@ -651,11 +674,9 @@ impl DataSection for MainDataV2 {
         bytes[220..222].copy_from_slice(&self.handler_memory.text_variable.to_le_bytes());
 
         bytes[222] = self.handler_affection;
-        // bytes[223..227].copy_from_slice(&self.super_training_flags.to_le_bytes());
-        // bytes[227] = self.super_training_dist_flags;
-
-        // bytes[229] = self.training_bag_hits;
-        // bytes[230] = self.training_bag;
+        if let Some(seconds) = self.started_tracking_seconds {
+            bytes[223..231].copy_from_slice(&seconds.get().to_le_bytes());
+        }
         // bytes[232] = self.poke_star_fame;
         bytes[233] = self.obedience_level;
 
@@ -777,6 +798,10 @@ impl Randomize for MainDataV2 {
             obedience_level: u8::randomized(rng),
             home_tracker: rand::random(),
             display_color_rgb: Option::<[u8; 3]>::randomized(rng),
+            started_tracking_seconds: match bool::randomized(rng) {
+                false => None,
+                true => NonZeroU64::new(rng.random_range(1..=current_time_unix_seconds().get())),
+            },
         }
     }
 }

--- a/src-tauri/src/state/ohpkm_store.rs
+++ b/src-tauri/src/state/ohpkm_store.rs
@@ -4,7 +4,9 @@ use crate::{state::synced_state, util};
 use base64::prelude::*;
 use pkm_rs::ohpkm::OhpkmV2;
 use serde::{Deserialize, Serialize};
+use std::num::NonZeroU64;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, UNIX_EPOCH};
 use std::{collections::HashMap, fs};
 
 #[derive(Default, Serialize, Deserialize, Clone)]
@@ -15,8 +17,8 @@ impl OhpkmBytesStore {
         let mon_files = fs::read_dir(path).map_err(|e| Error::file_access(&path, e))?;
 
         let mut map = HashMap::new();
-        for mon_file_os_str in mon_files.flatten() {
-            let path = mon_file_os_str.path();
+        for dir_entry in mon_files.flatten() {
+            let path = dir_entry.path();
             if !path
                 .extension()
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("ohpkm"))
@@ -25,12 +27,19 @@ impl OhpkmBytesStore {
             }
 
             if let Ok(mon_bytes) = util::read_file_bytes(path) {
-                let mon_identifier = mon_file_os_str
-                    .file_name()
-                    .to_string_lossy()
-                    .trim_end_matches(".ohpkm")
-                    .to_owned();
-                map.insert(mon_identifier, mon_bytes);
+                let file_created_seconds = dir_entry
+                    .metadata()
+                    .ok()
+                    .and_then(|m| m.created().or(m.modified()).ok())
+                    .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+                    .as_ref()
+                    .map(Duration::as_secs)
+                    .and_then(NonZeroU64::new);
+
+                if let Ok(mut mon) = OhpkmV2::from_bytes(&mon_bytes, file_created_seconds) {
+                    mon.set_started_tracking_if_missing(file_created_seconds);
+                    map.insert(mon.openhome_id(), mon.to_bytes());
+                }
             }
         }
 
@@ -43,7 +52,7 @@ impl OhpkmBytesStore {
 
     fn fix_errors(&mut self) {
         for (identifier, bytes) in self.0.iter_mut() {
-            if let Ok(mut mon) = OhpkmV2::from_bytes(bytes) {
+            if let Ok(mut mon) = OhpkmV2::from_bytes(bytes, None) {
                 let had_errors = mon.fix_errors();
                 if had_errors {
                     println!(

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -65,7 +65,7 @@ import {
   getPrevos,
   ivsFromDVs,
 } from './util'
-import dayjs from 'dayjs'
+import dayjs, { Dayjs } from 'dayjs'
 
 export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
   static getFormat() {
@@ -565,6 +565,12 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
   get startedTrackingTimestamp() {
     const timestampSeconds = this.startedTrackingSeconds
     return timestampSeconds ? dayjs.unix(Number(timestampSeconds)) : undefined
+  }
+
+  set startedTrackingTimestamp(timestamp: Option<Dayjs>) {
+    if (timestamp) {
+      this.startedTrackingSeconds = BigInt(timestamp.unix())
+    }
   }
 
   // derived fields

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -65,6 +65,7 @@ import {
   getPrevos,
   ivsFromDVs,
 } from './util'
+import dayjs from 'dayjs'
 
 export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
   static getFormat() {
@@ -559,6 +560,11 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
 
   set pluginOrigin(origin: Option<PluginIdentifier>) {
     this.pluginOriginWasm = origin
+  }
+
+  get startedTrackingTimestamp() {
+    const timestampSeconds = this.startedTrackingSeconds
+    return timestampSeconds ? dayjs.unix(Number(timestampSeconds)) : undefined
   }
 
   // derived fields

--- a/src/ui/pokemon-details/Modal.tsx
+++ b/src/ui/pokemon-details/Modal.tsx
@@ -299,6 +299,10 @@ const PokemonDetailsModal = (props: {
             </Flex>
             <Separator orientation="vertical" />
             <div>Level {mon.getLevel()}</div>
+            <div style={{ flex: 1 }} />
+            {mon instanceof OHPKM && (
+              <div>Tracked since {mon.startedTrackingTimestamp?.format('MMMM D, YYYY')}</div>
+            )}
           </div>
           {navigateLeft && (
             <button className="modal-arrow modal-arrow-left" onClick={navigateLeft}>

--- a/src/ui/pokemon-details/style.css
+++ b/src/ui/pokemon-details/style.css
@@ -17,7 +17,7 @@
 
 .modal-footer {
   background-color: var(--color-bar);
-  padding: 0.2rem;
+  padding: 0.2rem 0.5rem;
   font-size: 0.75rem;
   display: flex;
   flex-direction: row;

--- a/src/ui/state-zustand/banks-and-boxes/store.ts
+++ b/src/ui/state-zustand/banks-and-boxes/store.ts
@@ -332,9 +332,10 @@ function buildNewBox(
 
 function firstEmptyBoxSlot(box: SimpleOpenHomeBox): Option<number> {
   let firstEmptyIndex: Option<number> = undefined
-  for (const [index, contents] of box.identifiers) {
-    if (!contents && (firstEmptyIndex === undefined || firstEmptyIndex > index)) {
-      firstEmptyIndex = index
+  for (const boxSlot of range(0, OPENHOME_BOX_SLOTS)) {
+    const contents = box.identifiers.get(boxSlot)
+    if (!contents && (firstEmptyIndex === undefined || firstEmptyIndex > boxSlot)) {
+      firstEmptyIndex = boxSlot
     }
   }
 

--- a/src/ui/state/ohpkm/useOhpkmStore.ts
+++ b/src/ui/state/ohpkm/useOhpkmStore.ts
@@ -13,6 +13,7 @@ import { SAV } from '../../../core/save/interfaces'
 import { SAVClass } from '../../../core/save/util'
 import { useConvertStrategies } from '../convert-strategies'
 import { useLookups } from '../lookups'
+import dayjs from 'dayjs'
 
 export type OhpkmStore = {
   getById(id: string): OHPKM | undefined
@@ -134,6 +135,7 @@ export function useOhpkmStore(): OhpkmStore {
   const startTrackingNewMon = useCallback(
     <P extends PKMInterface>(mon: P, sourceSave: Option<SAV<P>>, destSave: Option<SAV>) => {
       const ohpkm = sourceSave ? OHPKM.fromMonInSave(mon, sourceSave) : new OHPKM(mon)
+      ohpkm.startedTrackingTimestamp = dayjs()
       if (destSave) {
         handleLookupsUpdate(ohpkm, destSave)
       }


### PR DESCRIPTION
**Description**

- Tracked Pokémon now store the timestamp of when they were first moved into OpenHome
  - For existing OHPKM files, the file creation timestamp is used
- Fixed visual bug in box overview screen