### PR TITLE
[FIX] Unbound/Radical Red Freeze

### DIFF
--- a/src/core/save/cfru/G3CFRUSAV.ts
+++ b/src/core/save/cfru/G3CFRUSAV.ts
@@ -108,6 +108,9 @@ class G3CFRUSaveBackup<T extends PluginPKMInterface> {
     })
 
     this.currentPCBox = this.pcDataContiguous[0]
+    if (this.currentPCBox >= boxCount) {
+      this.currentPCBox = 0
+    }
     this.boxNames = []
     this.boxes = new Array<Box<T>>(boxCount)
     for (let i = 0; i < boxCount; i++) {


### PR DESCRIPTION
**Description**

- Fixed bug where the app would freeze if an Unbound/Radical Red save's current box is one of the boxes OpenHome can't read yet (boxes past 18)

**Issue**

Fixes #636 
