### PR TITLE
fix(pkm_rs): use Gen V Poké Transfer met index (30001) in legalization

### DIFF
--- a/pkm_rs/src/format.rs
+++ b/pkm_rs/src/format.rs
@@ -308,8 +308,8 @@ impl PkmFormat {
         }
 
         if self.generation() >= Generation::G5 && legalized_origin.generation() <= Generation::G4 {
-            // Pokémon transferred up through Gen 5 have their location reset to the Poké Transfer Lab
-            return super::location::POKE_TRANSFER_LAB_GEN_5;
+            // Pokémon brought up through Gen V Poké Transfer use the transfer met index, not the Lab map index
+            return super::location::POKE_TRANSFER_MET_LOCATION_GEN_5;
         }
 
         let origin_was_changed = original_origin != legalized_origin;
@@ -338,7 +338,7 @@ impl PkmFormat {
             },
             Self::PK4 => location::gen4::index_of(location),
             Self::PK5 => match location {
-                Location::PokeTransferLab => Some(super::location::POKE_TRANSFER_LAB_GEN_5),
+                Location::PokeTransferLab => Some(super::location::POKE_TRANSFER_LAB_INDEX_GEN_5),
                 Location::LinkTrade => Some(30002),
                 Location::KantoGen3 => Some(30004),
                 Location::JohtoGen4 => Some(30005),

--- a/pkm_rs/src/location.rs
+++ b/pkm_rs/src/location.rs
@@ -353,7 +353,10 @@ pub enum Location {
 pub const CANT_TELL_GEN2: u16 = 126;
 pub const FATEFUL_ENCOUNTER_GEN_3: u16 = 255;
 pub const PAL_PARK_GEN_4: u16 = 55;
-pub const POKE_TRANSFER_LAB_GEN_5: u16 = 60;
+/// Gen V Unova map index for the Poké Transfer Lab building on Route 15.
+pub const POKE_TRANSFER_LAB_INDEX_GEN_5: u16 = 60;
+/// Gen V met location for Pokémon transferred from Gen IV or lower via Poké Transfer.
+pub const POKE_TRANSFER_MET_LOCATION_GEN_5: u16 = 30001;
 pub const GO_PARK_LETS_GO: u16 = 50;
 pub const FARAWAY_PLACE_SWSH: u16 = 40002;
 
@@ -808,7 +811,7 @@ mod tests {
 
             // Omega Ruby treated as Ruby
             assert_eq!(met_data.origin, OriginGame::Ruby);
-            assert_eq!(met_data.location_index, POKE_TRANSFER_LAB_GEN_5);
+            assert_eq!(met_data.location_index, POKE_TRANSFER_MET_LOCATION_GEN_5);
 
             Ok(())
         }
@@ -822,9 +825,9 @@ mod tests {
             let ohpkm = ohpkm_with_origin_and_location(OriginGame::Ruby, 200);
             let met_data = PkmFormat::PK8.met_data_maximizing_legality(&ohpkm);
 
-            // Gen 3 games use the poké transfer lab
+            // Gen 3 origin: Poké Transfer met location
             assert_eq!(met_data.origin, OriginGame::Ruby);
-            assert_eq!(met_data.location_index, POKE_TRANSFER_LAB_GEN_5);
+            assert_eq!(met_data.location_index, POKE_TRANSFER_MET_LOCATION_GEN_5);
 
             Ok(())
         }
@@ -834,9 +837,9 @@ mod tests {
             let ohpkm = ohpkm_with_origin_and_location(OriginGame::Diamond, 2000);
             let met_data = PkmFormat::PK8.met_data_maximizing_legality(&ohpkm);
 
-            // Gen 4 games use the poké transfer lab
+            // Gen 4 origin: Poké Transfer met location
             assert_eq!(met_data.origin, OriginGame::Diamond);
-            assert_eq!(met_data.location_index, POKE_TRANSFER_LAB_GEN_5);
+            assert_eq!(met_data.location_index, POKE_TRANSFER_MET_LOCATION_GEN_5);
 
             Ok(())
         }
@@ -862,7 +865,7 @@ mod tests {
             let ohpkm = ohpkm_with_origin_and_location(OriginGame::Ruby, 200);
             let met_data = PkmFormat::PB7.met_data_maximizing_legality(&ohpkm);
 
-            // Gen 3 games use the poké transfer lab
+            // Gen 3 origin: Let's Go uses the 3DS transfer slot index
             assert_eq!(met_data.origin, OriginGame::LetsGoEevee);
             assert_eq!(met_data.location_index, LinkTradeIndex::Pkm3dsSwitch as u16);
 
@@ -914,9 +917,9 @@ mod tests {
             let ohpkm = ohpkm_with_origin_and_location(OriginGame::Ruby, 200);
             let met_data = PkmFormat::PK8.met_data_maximizing_legality(&ohpkm);
 
-            // Gen 3 games use the poké transfer lab
+            // Gen 3 origin: Poké Transfer met location
             assert_eq!(met_data.origin, OriginGame::Ruby);
-            assert_eq!(met_data.location_index, POKE_TRANSFER_LAB_GEN_5);
+            assert_eq!(met_data.location_index, POKE_TRANSFER_MET_LOCATION_GEN_5);
 
             Ok(())
         }
@@ -926,9 +929,9 @@ mod tests {
             let ohpkm = ohpkm_with_origin_and_location(OriginGame::Diamond, 2000);
             let met_data = PkmFormat::PK8.met_data_maximizing_legality(&ohpkm);
 
-            // Gen 4 games use the poké transfer lab
+            // Gen 4 origin: Poké Transfer met location
             assert_eq!(met_data.origin, OriginGame::Diamond);
-            assert_eq!(met_data.location_index, POKE_TRANSFER_LAB_GEN_5);
+            assert_eq!(met_data.location_index, POKE_TRANSFER_MET_LOCATION_GEN_5);
 
             Ok(())
         }


### PR DESCRIPTION
## Description
### Problem
`legalize_met_location` used the Unova **map** index for the Poké Transfer Lab building (**60**) when handling Pokémon whose origin is Gen IV or lower on formats Gen V and above. Cartridge-accurate Poké Transfer uses **met location 30001**; the game derives region text from the Pokémon’s origin. Writing **60** could diverge from real saves and legality tools.
### Solution
- Introduce **`POKE_TRANSFER_MET_LOCATION_GEN_5`** (`30001`) and use it for the Gen V+ / ≤Gen IV transfer branch in `legalize_met_location`.
- Introduce **`POKE_TRANSFER_LAB_INDEX_GEN_5`** (`60`) for the Unova **“Poké Transfer Lab”** map row only—used when resolving `Location::PokeTransferLab` to a PK5 location index.

### Reference
Bulbapedia, *List of locations by index number in Generation V* — **30001** (transfer) vs **00060** (Lab map).