### PR TITLE
[FIX] Gen 7 Save OHPKM Updating

### DIFF
--- a/src/core/save/Gen7AlolaSave.ts
+++ b/src/core/save/Gen7AlolaSave.ts
@@ -19,6 +19,9 @@ export class Gen7AlolaSave extends WasmOfficialSave<PK7, Pk7Wasm> {
   static saveTypeAbbreviation = 'SM/USUM'
   static saveTypeID = 'SM/USUM'
 
+  MAX_BOX_COUNT: number = Gen7AlolaSaveRust.MAX_BOX_COUNT
+  SLOTS_PER_BOX: number = Gen7AlolaSaveRust.SLOTS_PER_BOX
+
   filePath: PathData
   fileCreated?: Date
 

--- a/src/core/save/interfaces.ts
+++ b/src/core/save/interfaces.ts
@@ -1,5 +1,5 @@
 import { PKMInterface } from '@openhome-core/pkm/interfaces'
-import { Option } from '@openhome-core/util/functional'
+import { Option, range } from '@openhome-core/util/functional'
 import { SaveRef } from '@openhome-core/util/types'
 import {
   ConvertStrategy,
@@ -400,9 +400,19 @@ export abstract class WasmOfficialSave<P extends PKMInterface, WasmP> extends Of
 
   abstract monFromWasm(wasmMon: WasmP): P
 
+  abstract MAX_BOX_COUNT: number
+  abstract SLOTS_PER_BOX: number
+
   getMonAt(boxNum: number, boxSlot: number): Option<P> {
     const wasmMon = this.inner.getMonAt(boxNum, boxSlot)
     return wasmMon ? this.monFromWasm(wasmMon) : undefined
+  }
+
+  getAllMons() {
+    return range(this.MAX_BOX_COUNT)
+      .flatMap((boxIndex) => range(this.SLOTS_PER_BOX).map((boxSlot) => ({ boxIndex, boxSlot })))
+      .map(({ boxIndex, boxSlot }) => this.getMonAt(boxIndex, boxSlot))
+      .filter(filterUndefined)
   }
 
   prepareForSaving(): Uint8Array {


### PR DESCRIPTION
**Description**

- A bug where Pokémon did not get their data updated from their time in gen 7 saves (3DS) has been fixed
  - This was caused by `WasmOfficialSave` not providing a `getAllMons()` method. It is now an abstract method and the type checker will force future Wasm save file formats to include the method.

**Issue**

Fixes #729 
