### PR TITLE
[ADD SUPPORT] Pokémon Compass

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ PKM and save files for the following ROM hacks are supported:
 - Pokémon Radical Red
 - Pokémon Unbound
 - Pokémon Luminescent Platinum
+- Pokémon Compass
 
 Forms exclusive to these ROM hacks can be moved into OpenHome and save files of other ROM hacks that support those forms. This includes forms like Stitched Gengar, Balloon Pikachu, and Seviian forms. Support for these forms is new and may have some bugs.
 
@@ -121,6 +122,8 @@ The following resources are sourced directly from the PKHeX codebase:
 Credit to the [Radical Red Team](https://www.pokecommunity.com/threads/pok%C3%A9mon-radical-red-version-4-1-released-gen-9-dlc-pokemon-character-customization-now-available.437688/) for the Radical Red logo, as well as the Pokémon sprites.
 
 Credit to [Team Luminescent](https://luminescent.team/) for the PKLumiHeX program, which provided critical information about the save file structure, and for the Luminescent Platinum logo.
+
+Credit to the [Pokémon Compass](https://www.nexusmods.com/pokemonscarletandviolet/mods/21) team for the game logo, as well as [PKCompassHeX](https://github.com/mtxCore/PKCompassHeX) for information on Compass save block keys.
 
 Pokémon Home extra form photoshops were created by [PkmnHomeIcons](https://github.com/nileplumb/PkmnHomeIcons). This includes Stitched Gengar, the Clone Pokémon, and the extra Pikachu forms.
 

--- a/packages/pokemon-files/src/pkm/PK9.ts
+++ b/packages/pokemon-files/src/pkm/PK9.ts
@@ -10,6 +10,7 @@ import {
   MarkingsSixShapesColors,
   MetadataSummaryLookup,
   NatureIndex,
+  PkmFormat,
   SpeciesLookup,
   TrainerMemory,
 } from '@pkm-rs/pkg'
@@ -28,10 +29,10 @@ import { MoveFilter } from '../util/util'
 import { PkmConstructorOptions } from './PKM'
 
 export default class PK9 {
-  static getFormat() {
-    return 'PK9' as const
+  static getFormat(): PkmFormat {
+    return 'PK9'
   }
-  format: 'PK9' = 'PK9'
+  format: PkmFormat = 'PK9'
   static getBoxSize() {
     return 344
   }

--- a/packages/pokemon-files/src/pkm/PKM.ts
+++ b/packages/pokemon-files/src/pkm/PKM.ts
@@ -1,9 +1,10 @@
-import { MonFormat, PKMInterface } from '@openhome-core/pkm/interfaces'
+import { PKMInterface } from '@openhome-core/pkm/interfaces'
 import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import PB8LUMI from '@openhome-core/save/luminescentplatinum/PB8LUMI'
 import PK3RR from '@openhome-core/save/radicalred/PK3RR'
 import PK3UB from '@openhome-core/save/unbound/PK3UB'
-import { ConvertStrategy } from '@pkm-rs/pkg'
+import { ConvertStrategy, PkmFormat } from '@pkm-rs/pkg'
+import PK9Compass from 'src/core/save/compass/PK9Compass'
 import COLOPKM from './COLOPKM'
 import PA8 from './PA8'
 import PA9 from './PA9'
@@ -45,12 +46,12 @@ export function isWasmFormat(pkm: PKMInterface): pkm is WasmPkmFormat {
   return WasmPkmFormats.some((P) => pkm instanceof P)
 }
 
-export type RomHackPKM = PK3RR | PK3UB | PB8LUMI
+export type RomHackPKM = PK3RR | PK3UB | PB8LUMI | PK9Compass
 
 export type PkmClass<P extends PKMInterface> = {
   fromBytes(bytes: ArrayBuffer, encrypted?: boolean): P
   fromOhpkm(ohpkm: OHPKM, strategy: ConvertStrategy): P
-  getFormat(): MonFormat
+  getFormat(): PkmFormat
 }
 
 export type PkmConstructorOptions =

--- a/packages/pokemon-files/src/util/pkmInterface.ts
+++ b/packages/pokemon-files/src/util/pkmInterface.ts
@@ -10,18 +10,18 @@ import {
   HyperTraining,
   Language,
   NatureIndex,
-  PkmFormat,
   ShinyLeaves,
   StatsPreSplit,
   TrainerMemory,
 } from '@pkm-rs/pkg'
+import { PkmOrOhpkmFormat } from 'src/core/pkm/util'
 import * as types from './types'
 import { Markings } from './types'
 
 export type FourMoves = [number, number, number, number]
 
 export interface AllPKMFields {
-  format: PkmFormat | 'OHPKM'
+  format: PkmOrOhpkmFormat
   ability?: AbilityIndex
   abilityNum?: number
   affixedRibbon?: number | undefined

--- a/packages/pokemon-files/src/util/statCalc.ts
+++ b/packages/pokemon-files/src/util/statCalc.ts
@@ -3,6 +3,7 @@ import { NationalDex, NationalDexMax } from '@pokemon-resources/consts/NationalD
 import { PKM } from '@pokemon-files/pkm/PKM'
 
 import { MetadataSummaryLookup, SpeciesLookup, Stat, Stats as StatsWasm } from '@pkm-rs/pkg'
+import { PK1, PK2 } from '@pokemon-files/pkm'
 import {
   AllPKMs,
   PKMWithDVs,
@@ -23,7 +24,7 @@ export interface PKMWithStandardStatCalc
 export interface PKMWithGameBoyStats extends AllPKMs, PKMWithDVs, PKMWithGameBoyEVs {}
 
 export function getStats(mon: PKM): Stats {
-  if (mon.format === 'PK1' || mon.format === 'PK2') {
+  if (mon instanceof PK1 || mon instanceof PK2) {
     return getGameBoyPKMStats(mon)
   }
 

--- a/pkm_rs/src/format.rs
+++ b/pkm_rs/src/format.rs
@@ -8,11 +8,15 @@ use pkm_rs_types::{Generation, OriginGame};
 #[cfg(feature = "wasm")]
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
+use strum::EnumIter;
+#[cfg(feature = "wasm")]
+use strum::IntoEnumIterator;
+#[cfg(feature = "wasm")]
 use tsify::Tsify;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 
-#[cfg_attr(feature = "wasm", derive(Tsify, Serialize, Deserialize))]
+#[cfg_attr(feature = "wasm", derive(Tsify, Serialize, Deserialize, EnumIter))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PkmFormat {
@@ -37,6 +41,7 @@ pub enum PkmFormat {
     PK3RR,
     PK3UB,
     PB8LUMI,
+    PK9Compass,
 }
 
 impl PkmFormat {
@@ -65,6 +70,7 @@ impl PkmFormat {
             Self::PA9 => OriginGame::LegendsZa,
             Self::PK3RR | Self::PK3UB => OriginGame::FireRed,
             Self::PB8LUMI => OriginGame::BrilliantDiamond,
+            Self::PK9Compass => OriginGame::Scarlet,
         }
     }
 
@@ -84,7 +90,8 @@ impl PkmFormat {
             Self::PB8 => origin.is_bdsp(),
             Self::PK9 => origin.is_scarlet_violet(),
             Self::PA9 => origin == OriginGame::LegendsZa,
-            Self::PK3RR | Self::PK3UB | Self::PB8LUMI => false,
+
+            Self::PK3RR | Self::PK3UB | Self::PB8LUMI | Self::PK9Compass => false,
         }
     }
 
@@ -99,8 +106,10 @@ impl PkmFormat {
             Self::PK7 | Self::PB7 => Generation::G7,
             Self::PK8 | Self::PA8 | Self::PB8 => Generation::G8,
             Self::PK9 | Self::PA9 => Generation::G9,
+
             Self::PK3RR | Self::PK3UB => Generation::G3,
             Self::PB8LUMI => Generation::G8,
+            Self::PK9Compass => Generation::G9,
         }
     }
 
@@ -112,6 +121,7 @@ impl PkmFormat {
             | Self::PB8
             | Self::PB8LUMI
             | Self::PK9
+            | Self::PK9Compass
             | Self::PA9 => true,
             Self::PK1
             | Self::PK2
@@ -153,7 +163,7 @@ impl PkmFormat {
             | Self::PA9 => LinkTradeIndex::Pkm3dsSwitch as u16,
 
             Self::PK3RR | Self::PK3UB => LinkTradeIndex::PkmGen3 as u16,
-            Self::PB8LUMI => LinkTradeIndex::Pkm3dsSwitch as u16,
+            Self::PB8LUMI | Self::PK9Compass => LinkTradeIndex::Pkm3dsSwitch as u16,
         }
     }
 
@@ -179,6 +189,7 @@ impl PkmFormat {
             Self::PK3RR => origin.generation() == Generation::G3,
             Self::PK3UB => origin.generation() == Generation::G3,
             Self::PB8LUMI => origin <= OriginGame::LegendsArceus,
+            Self::PK9Compass => origin <= OriginGame::Violet,
         }
     }
 
@@ -282,6 +293,7 @@ impl PkmFormat {
             Self::PK3RR => FireRed,
             Self::PK3UB => FireRed,
             Self::PB8LUMI => ShiningPearl,
+            Self::PK9Compass => Scarlet,
         }
     }
 
@@ -797,7 +809,7 @@ impl PkmFormat {
                 Location::SecretBase => Some(627),
                 _ => None,
             },
-            Self::PK9 => match location {
+            Self::PK9 | Self::PK9Compass => match location {
                 Location::LinkTrade => Some(30001),
                 Location::KantoGen3 => Some(30003),
                 Location::JohtoGen4 => Some(30004),
@@ -904,7 +916,7 @@ impl PkmFormat {
 
                 MetData::new(legalized_origin, location_index)
             }
-            PkmFormat::PK3RR | PkmFormat::PK3UB | PkmFormat::PB8LUMI => {
+            PkmFormat::PK3RR | PkmFormat::PK3UB | PkmFormat::PB8LUMI | PkmFormat::PK9Compass => {
                 let legalized_origin = self.legalize_origin(source_origin);
                 let location_index = self.legalize_met_location(
                     source_origin,
@@ -934,8 +946,9 @@ impl PkmFormat {
             Self::PK9 => MetadataSource::ScarletViolet,
             Self::PA9 => MetadataSource::LegendsZa,
 
-            Self::PB8LUMI => MetadataSource::BrilliantDiamondShiningPearl,
             Self::PK3RR | Self::PK3UB => MetadataSource::FireRedLeafGreen,
+            Self::PB8LUMI => MetadataSource::BrilliantDiamondShiningPearl,
+            Self::PK9Compass => MetadataSource::ScarletViolet,
         }
     }
 }
@@ -957,5 +970,10 @@ impl PkmFormats {
     #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "getMetadataSource"))]
     pub fn metadata_source_wasm(value: PkmFormat) -> MetadataSource {
         value.metadata_source()
+    }
+
+    #[cfg_attr(feature = "wasm", wasm_bindgen)]
+    pub fn all() -> Vec<PkmFormat> {
+        PkmFormat::iter().collect()
     }
 }

--- a/pkm_rs/src/ohpkm/v2_sections/pkm_bytes.rs
+++ b/pkm_rs/src/ohpkm/v2_sections/pkm_bytes.rs
@@ -1,3 +1,4 @@
+use crate::format::PkmFormat;
 use crate::ohpkm::v2::OhpkmSectionTag;
 use crate::result::{Error, Result};
 use crate::sectioned_data::DataSection;
@@ -45,6 +46,7 @@ pub enum Tag {
     Pk3Rr = 0xfffe,
     Pk3Ub = 0xfffd,
     Pb8Lumi = 0xfffc,
+    Pk9Compass = 0xfffb,
 }
 
 impl Tag {
@@ -75,11 +77,37 @@ impl TryFrom<u16> for Tag {
             0xfffe => Ok(Self::Pk3Rr),
             0xfffd => Ok(Self::Pk3Ub),
             0xfffc => Ok(Self::Pb8Lumi),
+            0xfffb => Ok(Self::Pk9Compass),
 
             other => Err(Error::TagError {
                 tag_type: "OriginalBackup",
                 value: other,
             }),
+        }
+    }
+}
+
+impl From<PkmFormat> for Option<Tag> {
+    fn from(value: PkmFormat) -> Self {
+        match value {
+            PkmFormat::PK1 => Some(Tag::Pk1),
+            PkmFormat::PK2 => Some(Tag::Pk2),
+            PkmFormat::PK3 => Some(Tag::Pk3),
+            PkmFormat::ColoPkm | PkmFormat::XdPkm => None,
+            PkmFormat::PK4 => Some(Tag::Pk4),
+            PkmFormat::PK5 => Some(Tag::Pk5),
+            PkmFormat::PK6 => Some(Tag::Pk6),
+            PkmFormat::PK7 => Some(Tag::Pk7),
+            PkmFormat::PB7 => Some(Tag::Pb7),
+            PkmFormat::PK8 => Some(Tag::Pk8),
+            PkmFormat::PA8 => Some(Tag::Pa8),
+            PkmFormat::PB8 => Some(Tag::Pb8),
+            PkmFormat::PK9 => Some(Tag::Pk9),
+            PkmFormat::PA9 => Some(Tag::Pa9),
+            PkmFormat::PK3RR => Some(Tag::Pk3Rr),
+            PkmFormat::PK3UB => Some(Tag::Pk3Ub),
+            PkmFormat::PB8LUMI => Some(Tag::Pb8Lumi),
+            PkmFormat::PK9Compass => Some(Tag::Pk9Compass),
         }
     }
 }
@@ -104,6 +132,7 @@ impl Tag {
             Self::Pk3Rr => PK3CFRU_PARTY_SIZE,
             Self::Pk3Ub => PK3CFRU_PARTY_SIZE,
             Self::Pb8Lumi => PB8LUMI_SIZE,
+            Self::Pk9Compass => PK9_SIZE,
         }
     }
 }
@@ -127,6 +156,7 @@ pub enum StoredPkmBytes {
     Pk3Rr([u8; PK3CFRU_PARTY_SIZE]),
     Pk3Ub([u8; PK3CFRU_PARTY_SIZE]),
     Pb8Lumi([u8; PB8_SIZE]),
+    Pk9Compass([u8; PK9_SIZE]),
 }
 
 const LENGTH_CHECKED_MESSAGE: &str = "data length checked above";
@@ -151,6 +181,7 @@ impl StoredPkmBytes {
             Self::Pk3Rr(bytes) => bytes,
             Self::Pk3Ub(bytes) => bytes,
             Self::Pb8Lumi(bytes) => bytes,
+            Self::Pk9Compass(bytes) => bytes,
         };
         bytes
     }
@@ -174,6 +205,7 @@ impl StoredPkmBytes {
             Self::Pk3Rr(_) => Tag::Pk3Rr,
             Self::Pk3Ub(_) => Tag::Pk3Ub,
             Self::Pb8Lumi(_) => Tag::Pb8Lumi,
+            Self::Pk9Compass(_) => Tag::Pk9Compass,
         }
     }
 
@@ -204,6 +236,7 @@ impl StoredPkmBytes {
             Tag::Pk3Rr => Ok(Self::Pk3Rr(copy_to_sized_array(data))),
             Tag::Pk3Ub => Ok(Self::Pk3Ub(copy_to_sized_array(data))),
             Tag::Pb8Lumi => Ok(Self::Pb8Lumi(copy_to_sized_array(data))),
+            Tag::Pk9Compass => Ok(Self::Pk9Compass(copy_to_sized_array(data))),
         }
     }
 

--- a/src/core/pkm/FileImport.ts
+++ b/src/core/pkm/FileImport.ts
@@ -4,6 +4,7 @@ import PB8LUMI from '@openhome-core/save/luminescentplatinum/PB8LUMI'
 import PK3RR from '@openhome-core/save/radicalred/PK3RR'
 import PK3UB from '@openhome-core/save/unbound/PK3UB'
 import { AnyPkmClass, SavePkmClass } from '@openhome-core/save/util'
+import { PkmFormat } from '@pkm-rs/pkg/pkm_rs'
 import {
   COLOPKM,
   PA8,
@@ -21,6 +22,8 @@ import {
   PK9,
   XDPKM,
 } from '@pokemon-files/pkm'
+import PK9Compass from '../save/compass/PK9Compass'
+import { isPkmFormat, PkmOrOhpkmFormat } from './util'
 
 function fileTypeFromBytes(bytes: Uint8Array): SavePkmClass | undefined {
   switch (bytes.length) {
@@ -44,8 +47,9 @@ function fileTypeFromBytes(bytes: Uint8Array): SavePkmClass | undefined {
   }
 }
 
-export function fileTypeFromStringNonOhpkm(type: string): SavePkmClass | undefined {
-  switch (type) {
+export function fileTypeFromStringNonOhpkm(type: PkmFormat): SavePkmClass | undefined {
+  const typeUpper = type.toUpperCase() as Uppercase<PkmFormat>
+  switch (typeUpper) {
     case 'PK1':
       return PK1
     case 'PK2':
@@ -80,15 +84,15 @@ export function fileTypeFromStringNonOhpkm(type: string): SavePkmClass | undefin
       return PB8LUMI
     case 'PK9':
       return PK9
+    case 'PK9COMPASS':
+      return PK9Compass
     case 'PA9':
       return PA9
-    default:
-      return undefined
   }
 }
 
-export function fileTypeFromString(type: string): AnyPkmClass | undefined {
-  if (type.toUpperCase() === 'OHPKM') {
+export function fileTypeFromString(type: PkmOrOhpkmFormat): AnyPkmClass | undefined {
+  if (type === 'OHPKM') {
     return OHPKM
   }
   return fileTypeFromStringNonOhpkm(type)
@@ -99,9 +103,12 @@ export const bytesToPKM = (bytes: Uint8Array, extension: string): PKMInterface =
 
   if (extension === '' || extension.toUpperCase() === 'PKM') {
     T = fileTypeFromBytes(new Uint8Array(bytes))
-  } else {
+  } else if (isPkmFormat(extension) || extension === 'OHPKM') {
     T = fileTypeFromString(extension)
+  } else {
+    console.error(`unknown pkm extension: ${extension}`)
   }
+
   if (!T) {
     throw `Unrecognized file`
   }

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -12,6 +12,7 @@ import {
   MetadataSummaryLookup,
   NatureIndex,
   OriginGames,
+  PkmFormat,
   PokeDate,
   ShinyLeaves,
   SpeciesAndForm,
@@ -322,7 +323,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
       this.tmFlagsSV = other.tmFlagsSV
       this.tmFlagsSVDLC = other.tmFlagsSVDLC
 
-      if (other.originalBytes) {
+      if (other.originalBytes && other.format !== 'OHPKM') {
         const tag = monFormatToOriginalDataTag(other.format)
         if (tag) {
           try {
@@ -653,6 +654,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
     }
 
     if (
+      other.format !== 'OHPKM' && // for type checking
       FORMATS_ALLOWING_ABILITY_CHANGE.includes(other.format) &&
       other.ability &&
       !FORMATS_WITHOUT_ABILITIES.includes(other.format)
@@ -941,7 +943,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
   }
 }
 
-export function monFormatToOriginalDataTag(format: string): Option<Tag> {
+export function monFormatToOriginalDataTag(format: PkmFormat): Option<Tag> {
   switch (format) {
     case 'PK1':
       return Tag.Pk1
@@ -975,10 +977,19 @@ export function monFormatToOriginalDataTag(format: string): Option<Tag> {
       return Tag.Pk3Ub
     case 'PB8LUMI':
       return Tag.Pb8Lumi
+    case 'PK9Compass':
+      return Tag.Pk9Compass
+    case 'COLOPKM':
+    case 'XDPKM':
+      return undefined
+    default:
+      // use type system to enforce exhaustiveness
+      const _exhaustiveCheck: never = format
+      throw Error(`unrecognized format: ${format}`)
   }
 }
 
-export function originalDataTagToMonFormat(tag: Tag): string {
+export function originalDataTagToMonFormat(tag: Tag): PkmFormat {
   switch (tag) {
     case Tag.Pk1:
       return 'PK1'
@@ -1012,12 +1023,20 @@ export function originalDataTagToMonFormat(tag: Tag): string {
       return 'PK3RR'
     case Tag.Pk3Ub:
       return 'PK3UB'
+    case Tag.Pk3Ub:
+      return 'PK3UB'
+    case Tag.Pk9Compass:
+      return 'PK9Compass'
+    default:
+      // use type system to enforce exhaustiveness
+      const _exhaustiveCheck: never = tag
+      throw Error(`unrecognized tag: ${tag}`)
   }
 }
 
-const FORMATS_WITHOUT_ABILITIES = ['PK1', 'PK2', 'PB7', 'PA8', 'PA9']
+const FORMATS_WITHOUT_ABILITIES: PkmFormat[] = ['PK1', 'PK2', 'PB7', 'PA8', 'PA9']
 
-const FORMATS_ALLOWING_ABILITY_CHANGE = [
+const FORMATS_ALLOWING_ABILITY_CHANGE: PkmFormat[] = [
   'PK3RR',
   'PK3UB',
   'PK6',
@@ -1028,9 +1047,10 @@ const FORMATS_ALLOWING_ABILITY_CHANGE = [
   'PK9',
   'PA9',
   'PB8LUMI',
+  'PK9Compass',
 ]
 
-const FORMATS_WITHOUT_HIDDEN_ABILITIES = ['PK3', 'COLOPKM', 'XDPKM', 'PK4']
+const FORMATS_WITHOUT_HIDDEN_ABILITIES: PkmFormat[] = ['PK3', 'COLOPKM', 'XDPKM', 'PK4']
 
 function isPrevoOrCurrentSpeciesName(
   dexNum: number,

--- a/src/core/pkm/interfaces.ts
+++ b/src/core/pkm/interfaces.ts
@@ -37,5 +37,5 @@ export type RomHackFormat = RomHackPKM['format']
 export type MonFormat = OfficialFormat | RomHackFormat
 
 export function isRomHackFormat(format: string): format is RomHackFormat {
-  return format === 'PK3RR' || format === 'PK3UB' || format === 'PB8LUMI'
+  return format === 'PK3RR' || format === 'PK3UB' || format === 'PB8LUMI' || format === 'PK9Compass'
 }

--- a/src/core/pkm/util.ts
+++ b/src/core/pkm/util.ts
@@ -8,6 +8,8 @@ import {
   metadataReaderFor,
   MetadataSource,
   MetadataSummaryLookup,
+  PkmFormat,
+  PkmFormats,
   PkmType,
   SpeciesAndForm,
   StatsPreSplit,
@@ -203,6 +205,7 @@ function MetadataSourceByFormat(format: MonFormat): MetadataSource {
     case 'PK9':
     case 'PK3RR':
     case 'PK3UB':
+    case 'PK9Compass':
       return MetadataSource.ScarletViolet
     case 'PA9':
       return MetadataSource.LegendsZa
@@ -431,3 +434,9 @@ export function displayIndexAdder(itemIndex?: number) {
   }
   return (x: number) => x + 1
 }
+
+export function isPkmFormat(value: string): value is PkmFormat {
+  return PkmFormats.all().includes(value as unknown as PkmFormat)
+}
+
+export type PkmOrOhpkmFormat = PkmFormat | 'OHPKM'

--- a/src/core/save/compass/CompassSave.ts
+++ b/src/core/save/compass/CompassSave.ts
@@ -13,7 +13,6 @@ import { isRestricted } from '@openhome-core/save/util/TransferRestrictions'
 import { Option } from '@openhome-core/util/functional'
 import { ConvertStrategy, ExtraFormIndex, Gender, Languages, OriginGame } from '@pkm-rs/pkg'
 import { utf16BytesToString } from '@pokemon-files/index'
-import { PK9 } from '@pokemon-files/pkm'
 import { Item } from '@pokemon-resources/consts/Items'
 import {
   SV_TRANSFER_RESTRICTIONS_BASE,
@@ -21,6 +20,7 @@ import {
   SV_TRANSFER_RESTRICTIONS_TM,
 } from '@pokemon-resources/consts/TransferRestrictions'
 import { G89BlockName } from 'src/core/save/Gen89/Gen8Gen9Save'
+import PK9Compass from './PK9Compass'
 
 const SAVE_SIZE_BYTES_MIN = 0x31626f
 // const SAVE_SIZE_BYTES_MAX_SV = 0x43c000
@@ -28,9 +28,9 @@ const SAVE_SIZE_BYTES_MAX_COMPASS = 0x43d000
 
 export type SV_SAVE_REVISION = 'Base Game' | 'Teal Mask' | 'Indigo Disk'
 
-export class CompassSave extends PluginSAV<PK9> {
-  static boxSizeBytes = PK9.getBoxSize() * 30
-  static pkmType = PK9
+export class CompassSave extends PluginSAV<PK9Compass> {
+  static boxSizeBytes = PK9Compass.getBoxSize() * 30
+  static pkmType = PK9Compass
   static saveTypeAbbreviation = 'Compass'
   static saveTypeName = 'Pokémon Compass'
   static saveTypeID = 'CMPSAV'
@@ -56,9 +56,9 @@ export class CompassSave extends PluginSAV<PK9> {
   sid: number = 0
   displayID: string = ''
 
-  currentPCBox: number = 0 // TODO: Gen 8 current box
+  currentPCBox: number = 0 // TODO: Gen 9 current box
 
-  boxes: Array<Box<PK9>>
+  boxes: Array<Box<PK9Compass>>
 
   bytes: Uint8Array
 
@@ -120,16 +120,16 @@ export class CompassSave extends PluginSAV<PK9> {
     this.origin = this.trainerBlock.getGame()
   }
 
-  convertOhpkm(ohpkm: OHPKM, strategy: ConvertStrategy): PK9 {
-    return PK9.fromOhpkm(ohpkm, strategy)
+  convertOhpkm(ohpkm: OHPKM, strategy: ConvertStrategy): PK9Compass {
+    return PK9Compass.fromOhpkm(ohpkm, strategy)
   }
 
   getBoxCount(): number {
     return 32
   }
 
-  monConstructor(bytes: ArrayBuffer, encrypted?: boolean): PK9 {
-    return new PK9(bytes, { encrypted })
+  monConstructor(bytes: ArrayBuffer, encrypted?: boolean): PK9Compass {
+    return new PK9Compass(bytes, { encrypted })
   }
 
   getBlockKey(blockName: G89BlockName | keyof typeof BlockKeys): number {
@@ -158,7 +158,7 @@ export class CompassSave extends PluginSAV<PK9> {
   }
 
   getMonBoxSizeBytes(): number {
-    return PK9.getBoxSize()
+    return PK9Compass.getBoxSize()
   }
 
   getBoxSizeBytes(): number {
@@ -273,7 +273,7 @@ export class CompassSave extends PluginSAV<PK9> {
     return box.boxSlots[boxSlot]
   }
 
-  setMonAt(boxNum: number, boxSlot: number, mon: Option<PK9>): void {
+  setMonAt(boxNum: number, boxSlot: number, mon: Option<PK9Compass>): void {
     const box = this.boxes[boxNum]
     if (!box) return
     box.boxSlots[boxSlot] = mon

--- a/src/core/save/compass/PK9Compass.ts
+++ b/src/core/save/compass/PK9Compass.ts
@@ -1,0 +1,45 @@
+import { PluginPKMInterface } from '@openhome-core/pkm/interfaces'
+import { OHPKM } from '@openhome-core/pkm/OHPKM'
+import { ConvertStrategy, OriginGames, PkmFormat } from '@pkm-rs/pkg'
+import PK9 from '@pokemon-files/pkm/PK9'
+import { PkmConstructorOptions } from '@pokemon-files/pkm/PKM'
+import { getStats } from '@pokemon-files/util/statCalc'
+import { PluginIdentifier } from '../interfaces'
+
+const COMPASS_PLUGIN_ID = 'compass'
+
+export default class PK9Compass extends PK9 implements PluginPKMInterface {
+  static getFormat(): PkmFormat {
+    return 'PK9Compass'
+  }
+  public format: PkmFormat = 'PK9Compass'
+  public pluginOrigin?: PluginIdentifier
+  public pluginIdentifier: PluginIdentifier = COMPASS_PLUGIN_ID
+  public get selectColor() {
+    return OriginGames.pluginColor(COMPASS_PLUGIN_ID)
+  }
+
+  constructor(arg: ArrayBuffer | OHPKM, options: PkmConstructorOptions) {
+    super(arg, options)
+
+    if (arg instanceof ArrayBuffer) {
+      this.pluginOrigin = COMPASS_PLUGIN_ID
+    } else {
+      if (arg.pluginOrigin === COMPASS_PLUGIN_ID) {
+        this.pluginOrigin = COMPASS_PLUGIN_ID
+      }
+    }
+  }
+
+  static fromBytes(buffer: ArrayBuffer, encrypted?: boolean): PK9Compass {
+    return new PK9Compass(buffer, { encrypted })
+  }
+
+  static fromOhpkm(ohpkm: OHPKM, strategy: ConvertStrategy): PK9Compass {
+    return new PK9Compass(ohpkm, { strategy })
+  }
+
+  public getStats() {
+    return getStats(this)
+  }
+}

--- a/src/core/save/luminescentplatinum/PB8LUMI.ts
+++ b/src/core/save/luminescentplatinum/PB8LUMI.ts
@@ -3,7 +3,12 @@ import { PB8 } from '@pokemon-files/pkm'
 import { PluginIdentifier } from '../interfaces'
 
 import { Option } from '@openhome-core/util/functional'
-import { ConvertStrategy, ExtraFormIndex, luminescentSupportsExtraForm } from '@pkm-rs/pkg'
+import {
+  ConvertStrategy,
+  ExtraFormIndex,
+  luminescentSupportsExtraForm,
+  OriginGames,
+} from '@pkm-rs/pkg'
 import { PkmConstructorOptions } from '../../../../packages/pokemon-files/src/pkm/PKM'
 import { OHPKM } from '../../pkm/OHPKM'
 import { getLumiCustomForm as getLumiExtraFormIndex } from './conversion/LuminescentPlatinumFormMap'
@@ -28,7 +33,9 @@ export default class PB8LUMI extends PB8 implements PluginPKMInterface {
   public format: 'PB8LUMI' = 'PB8LUMI'
   public pluginOrigin?: PluginIdentifier
   public pluginIdentifier: PluginIdentifier = 'luminescent_platinum'
-  public selectColor = '#25c2a0'
+  public get selectColor() {
+    return OriginGames.pluginColor('luminescent_platinum')
+  }
 
   public lumiFormIndex: number
 

--- a/src/ui/components/FileTypeSelect.tsx
+++ b/src/ui/components/FileTypeSelect.tsx
@@ -4,6 +4,9 @@ import { unique } from '@openhome-core/util/functional'
 import { filterUndefined } from '@openhome-core/util/sort'
 import { AppInfoContext } from '@openhome-ui/state/appInfo'
 import { useContext, useMemo } from 'react'
+import { PkmOrOhpkmFormat } from 'src/core/pkm/util'
+import { colorIsDark } from '../util/color'
+import { cssClass } from '../util/style'
 
 const fileTypeColors: Record<string, string> = {
   OHPKM: '#748fcd',
@@ -30,7 +33,7 @@ interface FileTypeSelectProps {
   currentFormat: string
   color?: string
   formData: PKMInterface
-  onChange: (selectedFormat: string) => void
+  onChange: (selectedFormat: PkmOrOhpkmFormat) => void
   disabled?: boolean
 }
 
@@ -48,14 +51,21 @@ const FileTypeSelect = (props: FileTypeSelectProps) => {
     return supportedFormats
   }, [formData, getEnabledSaveTypes])
 
+  const backgroundColor = color ?? fileTypeColors[currentFormat]
+  const gameColorIsDark = colorIsDark(backgroundColor)
+
   return (
     <select
-      className="file-type-select"
+      className={cssClass('file-type-select')
+        .with('black-select-arrow')
+        .if(!gameColorIsDark)
+        .build()}
       value={currentFormat}
-      onChange={(e) => onChange(e.target.value)}
+      onChange={(e) => onChange(e.target.value as PkmOrOhpkmFormat)}
       style={{
         backgroundColor: color ?? fileTypeColors[currentFormat],
         backgroundImage: props.disabled ? 'none' : undefined,
+        color: gameColorIsDark ? 'white' : 'black',
       }}
       disabled={props.disabled}
     >

--- a/src/ui/components/components.css
+++ b/src/ui/components/components.css
@@ -177,6 +177,11 @@
   width: 0;
 }
 
+.black-select-arrow {
+  background: url('data:image/svg+xml;utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path fill="black" d="M7 10l5 5 5-5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>')
+    100% 50% no-repeat transparent;
+}
+
 .datagrid {
   position: relative;
   background-color: var(--gray-3);

--- a/src/ui/images/pokemon.ts
+++ b/src/ui/images/pokemon.ts
@@ -1,4 +1,9 @@
-import { displayIndexAdder, isBattleFormeItem, isMegaStone } from '@openhome-core/pkm/util'
+import {
+  displayIndexAdder,
+  isBattleFormeItem,
+  isMegaStone,
+  PkmOrOhpkmFormat,
+} from '@openhome-core/pkm/util'
 import { toGen3RRPokemonIndex } from '@openhome-core/save/radicalred/conversion/Gen3RRPokemonIndex'
 import { RRSprites } from '@openhome-core/save/radicalred/conversion/RadicalRedSprites'
 import { UBSprites } from '@openhome-core/save/unbound/conversion/UnboundSprites'
@@ -15,7 +20,7 @@ import { isRomHackFormat, MonFormat } from '../../core/pkm/interfaces'
 import { getLumiFormIndexByExtraFormIndex } from '../../core/save/luminescentplatinum/conversion/LuminescentPlatinumFormMap'
 import { toGen3UBPokemonIndex } from '../../core/save/unbound/conversion/Gen3UBPokemonIndex'
 
-export const fileToSpriteFolder: Record<MonFormat | 'OHPKM', string> = {
+export const fileToSpriteFolder: Record<PkmOrOhpkmFormat, string> = {
   PK1: 'gen1',
   PK2: 'gen2',
   PK3: 'gen3',
@@ -33,6 +38,7 @@ export const fileToSpriteFolder: Record<MonFormat | 'OHPKM', string> = {
   PB8: 'home',
   PB8LUMI: 'home',
   PK9: 'gen9',
+  PK9Compass: 'gen9',
   PA9: 'home',
   OHPKM: 'home',
 }

--- a/src/ui/pokemon-details/Modal.tsx
+++ b/src/ui/pokemon-details/Modal.tsx
@@ -10,6 +10,7 @@ import { ArrowLeftIcon, ArrowRightIcon } from '@openhome-ui/components/Icons'
 import SideTabs from '@openhome-ui/components/side-tabs/SideTabs'
 import useDisplayError from '@openhome-ui/hooks/displayError'
 import MiniBoxIndicator, { MiniBoxIndicatorProps } from '@openhome-ui/saves/boxes/MiniBoxIndicator'
+import { PkmFormat } from '@pkm-rs/pkg/pkm_rs'
 import { isRomHackFormat } from '@pokemon-files/pkm/PKM'
 import { FileSchemas } from '@pokemon-files/schema'
 import { Flex, Switch, VisuallyHidden } from '@radix-ui/themes'
@@ -115,7 +116,7 @@ const PokemonDetailsModal = (props: {
     }
   }
 
-  function switchFormat(newFormat: string) {
+  function switchFormat(newFormat: PkmFormat | 'OHPKM') {
     if (!mon) return
     if (mon.format === newFormat) {
       setDisplayMon(mon)

--- a/src/ui/state/ohpkm/useOhpkmStore.ts
+++ b/src/ui/state/ohpkm/useOhpkmStore.ts
@@ -197,6 +197,7 @@ export function useOhpkmStore(): OhpkmStore {
         case 'PB8':
         case 'PB8LUMI':
         case 'PK9':
+        case 'PK9Compass':
         case 'PA9': {
           const homeIdentifier = getMonFileIdentifier(mon)
           if (!homeIdentifier) {

--- a/src/ui/state/plugin/reducer.ts
+++ b/src/ui/state/plugin/reducer.ts
@@ -1,14 +1,14 @@
-import { MonFormat } from '@openhome-core/pkm/interfaces'
 import { Option } from '@openhome-core/util/functional'
 import { ExtraFormIndex } from '@pkm-rs/pkg'
 import { Reducer, createContext } from 'react'
+import { PkmOrOhpkmFormat } from 'src/core/pkm/util'
 import { ImageResponse } from 'src/ui/backend/backendInterface'
 import { PluginState } from './PluginProvider'
 
 export interface MonSpriteData {
   dexNum: number
   formNum: number
-  format: MonFormat | 'OHPKM'
+  format: PkmOrOhpkmFormat
   formArgument?: number
   heldItemIndex?: number
   isFemale?: boolean


### PR DESCRIPTION
**Description**

- Added support for Pokémon Compass
- Because the save and pkm structures are the same, these are the only changes compared to Scarlet/Violet:
  - Pokémon met in Compass will remember they were met in Compass 
  - A separate game name, color, and logo will display for Compass saves and the Compass origin
  - Compass save files have a higher file size ceiling

**Issue**
Fixes #651 
Fixes #741 
