### PR TITLE
[FIX] Gameboy nature generation

### DIFF
--- a/pkm_rs/src/convert_strategy/personality_value.rs
+++ b/pkm_rs/src/convert_strategy/personality_value.rs
@@ -27,7 +27,7 @@ impl NatureStrategy {
     }
 
     fn is_satisfied(&self, pid: u32, mon: &OhpkmV2) -> bool {
-        NatureIndex::new_from_pid(pid) == self.relevant_nature(mon)
+        NatureIndex::new_from_modulo(pid) == self.relevant_nature(mon)
     }
 }
 
@@ -215,7 +215,7 @@ mod test {
         let new_pid = strategy.get_modified_pid(&mon);
 
         let modest = NatureIndex::new_js(15);
-        assert_eq!(NatureIndex::new_from_pid(new_pid), modest);
+        assert_eq!(NatureIndex::new_from_modulo(new_pid), modest);
 
         Ok(())
     }
@@ -235,7 +235,7 @@ mod test {
         let new_pid = strategy.get_modified_pid(&mon);
 
         let mild = NatureIndex::new_js(16);
-        assert_eq!(NatureIndex::new_from_pid(new_pid), mild);
+        assert_eq!(NatureIndex::new_from_modulo(new_pid), mild);
 
         Ok(())
     }
@@ -255,7 +255,7 @@ mod test {
         let new_pid = strategy.get_modified_pid(&mon);
 
         assert!(pkm_rs_types::shiny_xor_value(new_pid, mon.trainer_id(), mon.secret_id()) < 8);
-        assert_eq!(NatureIndex::new_from_pid(new_pid), mon.nature());
+        assert_eq!(NatureIndex::new_from_modulo(new_pid), mon.nature());
         assert_eq!(
             mon.get_forme_metadata().gender_from_pid(new_pid),
             mon.gender()
@@ -279,7 +279,7 @@ mod test {
         let new_pid = strategy.get_modified_pid(&mon);
 
         assert!(pkm_rs_types::shiny_xor_value(new_pid, mon.trainer_id(), mon.secret_id()) >= 8);
-        assert_eq!(NatureIndex::new_from_pid(new_pid), mon.nature());
+        assert_eq!(NatureIndex::new_from_modulo(new_pid), mon.nature());
         assert_eq!(
             mon.get_forme_metadata().gender_from_pid(new_pid),
             mon.gender()

--- a/pkm_rs/src/gen3/pk3.rs
+++ b/pkm_rs/src/gen3/pk3.rs
@@ -245,7 +245,7 @@ impl Pk3 {
     }
 
     pub fn nature(&self) -> NatureIndex {
-        NatureIndex::new_from_pid(self.personality_value)
+        NatureIndex::new_from_modulo(self.personality_value)
     }
 
     pub fn species_and_form(&self) -> SpeciesAndForm {

--- a/pkm_rs_resources/src/natures.rs
+++ b/pkm_rs_resources/src/natures.rs
@@ -46,8 +46,8 @@ impl NatureIndex {
         }
     }
 
-    #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "newFromPid"))]
-    pub fn new_from_pid(val: u32) -> NatureIndex {
+    #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "newFromModulo"))]
+    pub fn new_from_modulo(val: u32) -> NatureIndex {
         Self((val % (NATURE_COUNT as u32)) as u8)
     }
 

--- a/src/core/pkm/COLOPKM.ts
+++ b/src/core/pkm/COLOPKM.ts
@@ -237,7 +237,7 @@ export default class COLOPKM {
   }
 
   public get nature() {
-    return NatureIndex.newFromPid(this.personalityValue)
+    return NatureIndex.newFromModulo(this.personalityValue)
   }
 
   public get abilityNum() {

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -142,13 +142,13 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
             ? this.metadata?.genderFromAtkDv(other.dvs.atk)
             : this.metadata?.genderFromPid(this.personalityValue)) ??
           Gender.Genderless
+        this.nature = other.nature ?? NatureIndex.newFromModulo(other.exp)
       } else {
         this.abilityNum = other.abilityNum ?? 0
         this.gender =
           other.gender ?? this.metadata?.genderFromPid(this.personalityValue) ?? Gender.Genderless
+        this.nature = other.nature ?? NatureIndex.newFromModulo(this.personalityValue)
       }
-
-      this.nature = other.nature ?? NatureIndex.newFromPid(this.personalityValue)
 
       this.ivs = other.ivs ?? (other.dvs !== undefined ? ivsFromDVs(other.dvs) : generateIVs(prng))
 

--- a/src/core/pkm/PA8.ts
+++ b/src/core/pkm/PA8.ts
@@ -251,7 +251,7 @@ export default class PA8 {
       }
       this.personalityValue = other.personalityValue
       this.nature = other.nature
-      this.statNature = other.statNature ?? NatureIndex.newFromPid(this.personalityValue)
+      this.statNature = other.statNature ?? NatureIndex.newFromModulo(this.personalityValue)
       this.isFatefulEncounter = other.isFatefulEncounter ?? false
       this.flag2LA = other.flag2LA ?? false
       this.gender = other.gender

--- a/src/core/pkm/PA9.ts
+++ b/src/core/pkm/PA9.ts
@@ -231,7 +231,7 @@ export default class PA9 {
       }
       this.personalityValue = other.personalityValue ?? 0
       this.nature = other.nature
-      this.statNature = other.statNature ?? NatureIndex.newFromPid(this.personalityValue)
+      this.statNature = other.statNature ?? NatureIndex.newFromModulo(this.personalityValue)
       this.isFatefulEncounter = other.isFatefulEncounter ?? false
       this.gender = other.gender ?? 0
       this.isAlpha = other.isAlpha ?? false

--- a/src/core/pkm/PK4.ts
+++ b/src/core/pkm/PK4.ts
@@ -406,7 +406,7 @@ export default class PK4 {
   }
 
   public get nature() {
-    return NatureIndex.newFromPid(this.personalityValue)
+    return NatureIndex.newFromModulo(this.personalityValue)
   }
 
   public get abilityNum() {

--- a/src/core/pkm/PK9.ts
+++ b/src/core/pkm/PK9.ts
@@ -235,7 +235,7 @@ export default class PK9 {
       }
       this.personalityValue = other.personalityValue ?? 0
       this.nature = other.nature
-      this.statNature = other.statNature ?? NatureIndex.newFromPid(this.personalityValue)
+      this.statNature = other.statNature ?? NatureIndex.newFromModulo(this.personalityValue)
       this.isFatefulEncounter = other.isFatefulEncounter ?? false
       this.gender = other.gender ?? 0
       this.formNum = other.formNum

--- a/src/core/pkm/XDPKM.ts
+++ b/src/core/pkm/XDPKM.ts
@@ -241,7 +241,7 @@ export default class XDPKM {
   }
 
   public get nature() {
-    return NatureIndex.newFromPid(this.personalityValue)
+    return NatureIndex.newFromModulo(this.personalityValue)
   }
 
   public get abilityNum() {

--- a/src/core/save/cfru/PK3CFRU.ts
+++ b/src/core/save/cfru/PK3CFRU.ts
@@ -442,7 +442,7 @@ export default abstract class PK3CFRU implements PluginPKMInterface {
   }
 
   public get nature() {
-    return NatureIndex.newFromPid(this.personalityValue)
+    return NatureIndex.newFromModulo(this.personalityValue)
   }
 
   public get abilityNum() {

--- a/src/core/util/util.ts
+++ b/src/core/util/util.ts
@@ -76,7 +76,7 @@ export function generatePersonalityValuePreservingAttributes(mon: AllPKMFields):
   let i = 0
   while (i < 0x10000) {
     const newGender = metadata.genderFromPid(Number(newPersonalityValue))
-    const newNature = NatureIndex.newFromPid(Number(newPersonalityValue))
+    const newNature = NatureIndex.newFromModulo(Number(newPersonalityValue))
 
     function getInconsistancy(): string | null {
       if (shouldCheckUnown && getUnownLetterGen3(Number(newPersonalityValue)) !== mon.formNum) {


### PR DESCRIPTION
**Description**

- Pokémon from gameboy games now have their nature generated from their exp value, the same way Poké Transporter does it. Previously they all erroneously defaulted to Hardy.

**Issue**

Fixes #773 
