### PR TITLE
[FEAT] indicator color + fix recent save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,7 +60,7 @@
   ],
   "editor.inlayHints.enabled": "off",
   "editor.tabSize": 2,
-  "rust-analyzer.cargo.features": [],
+  "rust-analyzer.cargo.features": "all",
   "css.completion.completePropertyWithSemicolon": false,
   "rust-analyzer.cargo.targetDir": true,
   "python.terminal.activateEnvironment": false

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -3453,13 +3453,7 @@ impl OhpkmV2 {
         trainer_name: String,
         save_path: String,
     ) {
-        self.most_recent_save = Some(MostRecentSave {
-            trainer_id,
-            secret_id,
-            game,
-            trainer_name: trainer_name.into(),
-            file_path: save_path,
-        })
+        self.set_recent_save(game, trainer_id, secret_id, trainer_name, save_path)
     }
 
     #[wasm_bindgen(js_name = getPresentSections)]

--- a/src/ui/components/pokemon/indicator/Indicator.css
+++ b/src/ui/components/pokemon/indicator/Indicator.css
@@ -23,12 +23,15 @@
   min-width: 1.25rem;
   height: 1.25rem;
   border-radius: var(--border-radius-xs);
+  outline: 1px solid black;
 }
 
 .numerical-indicator {
   font-size: 0.8rem;
   padding: var(--padding-radius-xs-sm);
   height: 1rem;
+  font-weight: bold;
+  color: black;
 }
 
 .image-indicator-with-text {

--- a/src/ui/components/pokemon/indicator/TopRightIndicator.tsx
+++ b/src/ui/components/pokemon/indicator/TopRightIndicator.tsx
@@ -1,4 +1,5 @@
 import { PKMInterface } from '@openhome-core/pkm/interfaces'
+import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import { StatsPreSplit } from '@pkm-rs/pkg/pkm_rs'
 import { TopRightIndicatorType } from '../../../hooks/monDisplay'
 import { getPublicImageURL } from '../../../images/images'
@@ -14,35 +15,44 @@ type TopRightIndicatorProps = {
   indicatorType: TopRightIndicatorType
 }
 
+const EV_STAT_MAX = 252
+const EV_TOTAL_MAX = 508
+const STAT_TYPE_COUNT = 6
+const MAX_LEVEL = 100
+
 export function TopRightIndicator({ mon, indicatorType }: TopRightIndicatorProps) {
   switch (indicatorType) {
     case 'Gender':
       return <GenderIcon gender={mon.gender} />
+    case 'Level':
+      return <NumericalIndicator value={mon.getLevel()} max={MAX_LEVEL} />
     case 'EVs (Total)':
       const evsTotal = Object.values(mon.evs ?? mon.evsG12 ?? {}).reduce((p, c) => p + c, 0)
-      return <NumericalIndicator value={evsTotal} />
+      return <NumericalIndicator value={evsTotal} max={EV_TOTAL_MAX} />
     case 'EV (HP)':
-      return <NumericalIndicator value={mon.evs?.hp} />
+      return <NumericalIndicator value={mon.evs?.hp} max={EV_STAT_MAX} />
     case 'EV (Attack)':
-      return <NumericalIndicator value={mon.evs?.atk} />
+      return <NumericalIndicator value={mon.evs?.atk} max={EV_STAT_MAX} />
     case 'EV (Defense)':
-      return <NumericalIndicator value={mon.evs?.def} />
+      return <NumericalIndicator value={mon.evs?.def} max={EV_STAT_MAX} />
     case 'EV (Special Attack)':
-      return <NumericalIndicator value={mon.evs?.spa} />
+      return <NumericalIndicator value={mon.evs?.spa} max={EV_STAT_MAX} />
     case 'EV (Special Defense)':
-      return <NumericalIndicator value={mon.evs?.spd} />
+      return <NumericalIndicator value={mon.evs?.spd} max={EV_STAT_MAX} />
     case 'EV (Speed)':
-      return <NumericalIndicator value={mon.evs?.spe} />
+      return <NumericalIndicator value={mon.evs?.spe} max={EV_STAT_MAX} />
     case 'IVs/DVs (Percent)':
       const ivsOrDvsPercent = mon.ivs ? getIvsPercent(mon) : hasDvs(mon) ? getDvsPercent(mon) : 0
       return <NumericalIndicator value={ivsOrDvsPercent} percent />
     case 'Perfect IVs Count':
       const perfectIvsCount = getPerfectIvsCount(mon)
-      return <NumericalIndicator value={perfectIvsCount} />
+      return <NumericalIndicator value={perfectIvsCount} max={STAT_TYPE_COUNT} />
     case 'Origin Game':
       return <GameIndicator originGame={mon.gameOfOrigin} plugin={mon.pluginOrigin} />
     case 'Most Recent Save':
-      return <NumericalIndicator value={mon.ribbons?.length} />
+      return mon instanceof OHPKM && <GameIndicator originGame={mon.mostRecentSaveWasm?.game} />
+    case 'Ribbon Count':
+      return <NumericalIndicator value={mon.ribbons?.length} max={3} /> // TODO: better handle color for ribbon count
     case 'Ball':
       return (
         mon.ball && (
@@ -77,17 +87,37 @@ export function TopRightIndicator({ mon, indicatorType }: TopRightIndicatorProps
 type TopRightNumericalIndicatorProps = {
   value?: number
   percent?: boolean
-}
+} & (
+  | {
+      percent?: false
+      max: number
+    }
+  | {
+      percent: true
+      max?: undefined
+    }
+)
 
 function hasDvs(mon: PKMInterface): mon is PKMInterface & { dvs: StatsPreSplit } {
   return (mon as any).dvs !== undefined
 }
 
-function NumericalIndicator({ value, percent }: TopRightNumericalIndicatorProps) {
+function colorByPercent(percent: number) {
+  if (percent < 30) return '#bbb'
+  if (percent < 65) return `hsl(39, 80%, 71%)`
+  if (percent < 90) return 'hsl(75, 80%, 70%)'
+  if (percent < 100) return 'hsl(105, 89%, 58%)'
+  return 'hsl(204, 99%, 65%)'
+}
+
+function NumericalIndicator({ value, percent, max: maxProp }: TopRightNumericalIndicatorProps) {
+  if (value === undefined) return null
+
+  const color = colorByPercent(percent ? value : Math.min((value / maxProp) * 100, 100))
   return (
     value !== undefined &&
     (percent || value > 0) && (
-      <Indicator className="numerical-indicator" backgroundColor="var(--accent-9)">
+      <Indicator className="numerical-indicator" backgroundColor={color}>
         {value}
         {percent ? '%' : ''}
       </Indicator>

--- a/src/ui/hooks/monDisplay.ts
+++ b/src/ui/hooks/monDisplay.ts
@@ -70,6 +70,7 @@ export const TopRightIndicatorTypes = [
   'Gender',
   'Origin Game',
   'Most Recent Save',
+  'Level',
   'EVs (Total)',
   'EV (HP)',
   'EV (Attack)',


### PR DESCRIPTION
**Description**

- Level can now be displayed in the top-right indicator
- Top-right indicator is now color coded based on its value and the max possible value
- Recent save indicator no longer erroneously displays ribbon count (but does not yet show plugins correctly)

**Issue**

Fixes #633 
Fixes #661 
