### PR TITLE
Fix Game Boy evolution family import collisions

### DIFF
--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -88,11 +88,12 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
 
         prng = new Prando(
           other.trainerName
+            .concat(other.dexNum.toString())
             .concat(`${hp}~${atk}~${def}~${spc}~${spe}`)
             .concat(other.trainerID.toString())
         )
 
-        this.personalityValue = this.generatePk3CompatiblePid()
+        this.personalityValue = prng.nextInt(0, 0xffffffff)
       } else {
         prng = new Prando(other.trainerName.concat(other.trainerID.toString()))
       }
@@ -144,6 +145,10 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
             : this.metadata?.genderFromPid(this.personalityValue)) ??
           Gender.Genderless
         this.nature = other.nature ?? NatureIndex.newFromModulo(other.exp)
+
+        if (other.personalityValue === undefined) {
+          this.personalityValue = this.generatePk3CompatiblePid()
+        }
       } else {
         this.abilityNum = other.abilityNum ?? 0
         this.gender =

--- a/src/core/pkm/__test__/Ohpkm.test.ts
+++ b/src/core/pkm/__test__/Ohpkm.test.ts
@@ -1,4 +1,4 @@
-import { PA8, PK3, PK4, PK7, PK8, PK9 } from '@openhome-core/pkm'
+import { PA8, PK2, PK3, PK4, PK7, PK8, PK9 } from '@openhome-core/pkm'
 import { NationalDex } from '@openhome-core/resources/consts/NationalDex'
 import PB8LUMI from '@openhome-core/save/luminescentplatinum/PB8LUMI'
 import { R } from '@openhome-core/util/functional'
@@ -148,6 +148,19 @@ describe('evolution and form change update ohpkm', async () => {
     expect(mrMimeOhpkm.dexNum).toEqual(NationalDex.MrRime)
     expect(mrMimeOhpkm.formNum).toEqual(0)
   })
+})
+
+test('Game Boy Pokemon in the same evolution family have distinct OpenHome IDs', () => {
+  const bytes = new Uint8Array(fs.readFileSync(pkmTestFilePath('pk2', 'hooh.pk2')))
+  const abra = PK2.fromBytes(bytes.buffer)
+  const kadabra = PK2.fromBytes(bytes.buffer.slice(0))
+
+  abra.dexNum = NationalDex.Abra
+  kadabra.dexNum = NationalDex.Kadabra
+
+  expect(OHPKM.fromMonUnknownSave(abra).openhomeId).not.toEqual(
+    OHPKM.fromMonUnknownSave(kadabra).openhomeId
+  )
 })
 
 describe('plugin form persistence', () => {


### PR DESCRIPTION
Fixes #833

Gen 1/2 Pokemon have no native personality value. Their OHPKM conversion now seeds a deterministic PID from the source Pokemon data before applying Gen 3 compatibility constraints, so related Pokemon do not share an OpenHome ID.

Adds a regression test for Abra and Kadabra constructed from the same Gen 2 source data.

Validation:
- pnpm exec vitest run src/core/pkm/__test__/Ohpkm.test.ts
- pnpm run test-vite
- pnpm run typecheck
- pnpm run lint:ci