### PR TITLE
[FIX] Stellar Tera conversion

### DIFF
--- a/pkm_rs/src/gen9_sv/pk9.rs
+++ b/pkm_rs/src/gen9_sv/pk9.rs
@@ -17,8 +17,6 @@ use pkm_rs_resources::moves::{MoveIndex, MoveSlots};
 use pkm_rs_resources::natures::NatureIndex;
 use pkm_rs_resources::ribbons::{ModernRibbon, ModernRibbonSet};
 use pkm_rs_resources::species::{FormMetadata, SpeciesForm, SpeciesMetadata};
-#[cfg(feature = "wasm")]
-use pkm_rs_types::TeraTypeWasm;
 use pkm_rs_types::strings::SizedUtf16String;
 use pkm_rs_types::{
     AbilityNumber, BinaryGender, ContestStats, FlagSet, HyperTraining, Ivs, Language,
@@ -562,23 +560,23 @@ impl Pk9 {
     }
 
     #[wasm_bindgen(getter = teraTypeOriginal)]
-    pub fn tera_type_original_wasm(&self) -> TeraTypeWasm {
+    pub fn tera_type_original_wasm(&self) -> TeraType {
         self.tera_type_original.into()
     }
 
     #[wasm_bindgen(setter = teraTypeOriginal)]
-    pub fn set_tera_type_original_wasm(&mut self, v: TeraTypeWasm) {
+    pub fn set_tera_type_original_wasm(&mut self, v: TeraType) {
         self.tera_type_original = v.into()
     }
 
     #[wasm_bindgen(getter = teraTypeOverride)]
-    pub fn tera_type_override_wasm(&self) -> Option<TeraTypeWasm> {
-        self.tera_type_override.map(TeraTypeWasm::from)
+    pub fn tera_type_override_wasm(&self) -> Option<TeraType> {
+        self.tera_type_override
     }
 
     #[wasm_bindgen(setter = teraTypeOverride)]
-    pub fn set_tera_type_override_wasm(&mut self, v: Option<TeraTypeWasm>) {
-        self.tera_type_override = v.map(TeraType::from)
+    pub fn set_tera_type_override_wasm(&mut self, v: Option<TeraType>) {
+        self.tera_type_override = v
     }
 
     #[wasm_bindgen(getter = obedienceLevel)]

--- a/pkm_rs/src/gen9_sv/pk9.rs
+++ b/pkm_rs/src/gen9_sv/pk9.rs
@@ -561,12 +561,12 @@ impl Pk9 {
 
     #[wasm_bindgen(getter = teraTypeOriginal)]
     pub fn tera_type_original_wasm(&self) -> TeraType {
-        self.tera_type_original.into()
+        self.tera_type_original
     }
 
     #[wasm_bindgen(setter = teraTypeOriginal)]
     pub fn set_tera_type_original_wasm(&mut self, v: TeraType) {
-        self.tera_type_original = v.into()
+        self.tera_type_original = v
     }
 
     #[wasm_bindgen(getter = teraTypeOverride)]

--- a/pkm_rs/src/ohpkm/issues.rs
+++ b/pkm_rs/src/ohpkm/issues.rs
@@ -24,30 +24,32 @@ pub enum OhpkmIssue {
         gender: Gender,
         ratio: GenderRatio,
     },
+    StellarTeraCorrupted,
 }
 
 impl Display for OhpkmIssue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            OhpkmIssue::SpeciesNameCorrupted {
+            Self::SpeciesNameCorrupted {
                 corrupted,
                 expected,
             } => f.write_str(&format!(
                 "Species name: expected {expected}; found {corrupted}"
             )),
-            OhpkmIssue::SpeciesNameAllCaps => f.write_str("Nickname is species name in all caps"),
-            OhpkmIssue::HadPrevoSpeciesName => f.write_str("Nickname is preevolution species name"),
-            OhpkmIssue::NicknameFlagIncorrect { expected } => {
+            Self::SpeciesNameAllCaps => f.write_str("Nickname is species name in all caps"),
+            Self::HadPrevoSpeciesName => f.write_str("Nickname is preevolution species name"),
+            Self::NicknameFlagIncorrect { expected } => {
                 f.write_str(&format!("Nickname flag should be {expected}"))
             }
-            OhpkmIssue::UnexpectedEggData => f.write_str("Unexpected egg data present"),
-            OhpkmIssue::AffixedRibbonNotPresent => f.write_str("Affixed ribbon not in possession"),
-            OhpkmIssue::AbilityNumIndexMismatch { index, number } => f.write_str(&format!(
+            Self::UnexpectedEggData => f.write_str("Unexpected egg data present"),
+            Self::AffixedRibbonNotPresent => f.write_str("Affixed ribbon not in possession"),
+            Self::AbilityNumIndexMismatch { index, number } => f.write_str(&format!(
                 "Ability index {index} does not match species + ability number {number}"
             )),
-            OhpkmIssue::InvalidGender { gender, ratio } => f.write_str(&format!(
+            Self::InvalidGender { gender, ratio } => f.write_str(&format!(
                 "Gender {gender} invalid for species gender ratio {ratio}"
             )),
+            Self::StellarTeraCorrupted => f.write_str("Stellar tera stored as invalid byte"),
         }
     }
 }

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -1768,7 +1768,15 @@ impl OhpkmV2 {
     }
 
     pub fn fix_errors(&mut self) -> Vec<OhpkmIssue> {
-        self.main_data.fix_errors()
+        let mut fixed_issues = Vec::<OhpkmIssue>::new();
+
+        fixed_issues.append(&mut self.main_data.fix_errors());
+
+        if let Some(sv_data) = self.sv_data.as_mut() {
+            fixed_issues.append(&mut sv_data.fix_errors());
+        }
+
+        fixed_issues
     }
 
     pub fn get_nickname(&self) -> String {

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -28,7 +28,7 @@ use pkm_rs_types::strings::SizedUtf16String;
 use pkm_rs_types::{
     AbilityNumber, BinaryGender, ContestStats, FlagSet, Gender, Geolocations, HyperTraining, Ivs,
     Language, MarkingsSixShapesColors, OriginGame, PokeDate, Pokerus, ShinyLeaves, Stats8,
-    Stats16Le, StatsPreSplit, TeraType, TeraTypeWasm, TrainerData, TrainerMemory,
+    Stats16Le, StatsPreSplit, TeraType, TrainerData, TrainerMemory,
 };
 use serde::Serialize;
 use strum_macros::Display;
@@ -1377,18 +1377,6 @@ impl OhpkmV2 {
                 .get_forme_metadata()
                 .transferred_tera_type(),
         )
-    }
-
-    pub fn set_tera_type_original_if(&mut self, value: Option<u8>) {
-        let Some(value) = value else { return };
-
-        if let Some(tera_type) = TeraTypeWasm::from_byte(value) {
-            self.sv_data
-                .get_or_insert(ScarletVioletData::default_generated_tera_type(
-                    self.main_data.species_and_form,
-                ))
-                .tera_type_original = tera_type.into()
-        }
     }
 
     pub fn tera_type_override(&self) -> Option<TeraType> {
@@ -3201,44 +3189,37 @@ impl OhpkmV2 {
     // Scarlet/Violet
 
     #[wasm_bindgen(getter = teraTypeOriginal)]
-    pub fn tera_type_original_js(&self) -> TeraTypeWasm {
-        self.sv_data
-            .map(|d| TeraTypeWasm::from(d.tera_type_original))
-            .unwrap_or(
-                self.species_and_form()
-                    .get_forme_metadata()
-                    .transferred_tera_type()
-                    .into(),
-            )
+    pub fn tera_type_original_js(&self) -> TeraType {
+        self.sv_data.map(|d| d.tera_type_original).unwrap_or(
+            self.species_and_form()
+                .get_forme_metadata()
+                .transferred_tera_type(),
+        )
     }
 
     #[wasm_bindgen(js_name = setTeraTypeOriginalIf)]
-    pub fn set_tera_type_original_if_js(&mut self, value: Option<u8>) {
+    pub fn set_tera_type_original_if_js(&mut self, value: Option<TeraType>) {
         let Some(value) = value else { return };
 
-        if let Some(tera_type) = TeraTypeWasm::from_byte(value) {
-            self.sv_data
-                .get_or_insert(ScarletVioletData::default_generated_tera_type(
-                    self.main_data.species_and_form,
-                ))
-                .tera_type_original = tera_type.into()
-        }
-    }
-
-    #[wasm_bindgen(getter = teraTypeOverride)]
-    pub fn tera_type_override_js(&self) -> u8 {
-        self.sv_data
-            .and_then(|d| d.tera_type_override)
-            .map_or(TeraType::NO_OVERRIDE, TeraType::to_byte)
-    }
-
-    #[wasm_bindgen(setter = teraTypeOverride)]
-    pub fn set_tera_type_override_js(&mut self, value: u8) -> Result<()> {
         self.sv_data
             .get_or_insert(ScarletVioletData::default_generated_tera_type(
                 self.main_data.species_and_form,
             ))
-            .tera_type_override = TeraType::from_byte_override(value)?;
+            .tera_type_original = value
+    }
+
+    #[wasm_bindgen(getter = teraTypeOverride)]
+    pub fn tera_type_override_js(&self) -> Option<TeraType> {
+        self.sv_data.and_then(|d| d.tera_type_override)
+    }
+
+    #[wasm_bindgen(setter = teraTypeOverride)]
+    pub fn set_tera_type_override_js(&mut self, value: Option<TeraType>) -> Result<()> {
+        self.sv_data
+            .get_or_insert(ScarletVioletData::default_generated_tera_type(
+                self.main_data.species_and_form,
+            ))
+            .tera_type_override = value;
 
         Ok(())
     }

--- a/pkm_rs/src/ohpkm/v2_sections.rs
+++ b/pkm_rs/src/ohpkm/v2_sections.rs
@@ -1,4 +1,5 @@
 use crate::gen9_sv;
+use crate::ohpkm::issues::OhpkmIssue;
 use crate::ohpkm::v2::OhpkmSectionTag;
 use crate::result::{Error, Result, StringErrorSource};
 use crate::sectioned_data::DataSection;
@@ -77,6 +78,27 @@ impl ScarletVioletData {
                 .transferred_tera_type(),
             ..Default::default()
         }
+    }
+
+    pub fn fix_errors(&mut self) -> Vec<OhpkmIssue> {
+        let mut issues: Vec<OhpkmIssue> = vec![];
+        // OpenHome incorrectly stored stellar tera pre-1.15.2
+        if let TeraType::Standard(tera_type) = self.tera_type_original
+            && tera_type as u8 == 18
+        {
+            self.tera_type_original = TeraType::Stellar;
+            issues.push(OhpkmIssue::StellarTeraCorrupted);
+        }
+
+        // OpenHome incorrectly stored stellar tera pre-1.15.2
+        if let Some(TeraType::Standard(tera_type)) = self.tera_type_override
+            && tera_type as u8 == 18
+        {
+            self.tera_type_override = Some(TeraType::Stellar);
+            issues.push(OhpkmIssue::StellarTeraCorrupted);
+        }
+
+        issues
     }
 }
 

--- a/pkm_rs_types/src/pkm_types.rs
+++ b/pkm_rs_types/src/pkm_types.rs
@@ -170,6 +170,8 @@ impl PkmTypes {
 const TERA_TYPE_STELLAR: u8 = 0x63;
 
 #[cfg_attr(feature = "randomize", derive(Randomize))]
+#[cfg_attr(feature = "wasm", derive(Tsify, Deserialize))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
 pub enum TeraType {
     Standard(PkmType),
@@ -216,86 +218,5 @@ impl TeraType {
 impl Default for TeraType {
     fn default() -> Self {
         Self::Standard(PkmType::default())
-    }
-}
-
-#[cfg(feature = "wasm")]
-#[wasm_bindgen]
-#[derive(Debug, Default, EnumString, Display, Serialize, PartialEq, Eq, Clone, Copy)]
-#[repr(u8)]
-pub enum TeraTypeWasm {
-    #[default]
-    Normal,
-    Fighting,
-    Flying,
-    Poison,
-    Ground,
-    Rock,
-    Bug,
-    Ghost,
-    Steel,
-    Fire,
-    Water,
-    Grass,
-    Electric,
-    Psychic,
-    Ice,
-    Dragon,
-    Dark,
-    Fairy,
-
-    Stellar = 99,
-}
-
-#[cfg(feature = "wasm")]
-#[allow(clippy::missing_const_for_fn)]
-impl TeraTypeWasm {
-    pub fn from_byte(byte: u8) -> Option<Self> {
-        match byte {
-            0 => Some(Self::Normal),
-            1 => Some(Self::Fighting),
-            2 => Some(Self::Flying),
-            3 => Some(Self::Poison),
-            4 => Some(Self::Ground),
-            5 => Some(Self::Rock),
-            6 => Some(Self::Bug),
-            7 => Some(Self::Ghost),
-            8 => Some(Self::Steel),
-            9 => Some(Self::Fire),
-            10 => Some(Self::Water),
-            11 => Some(Self::Grass),
-            12 => Some(Self::Electric),
-            13 => Some(Self::Psychic),
-            14 => Some(Self::Ice),
-            15 => Some(Self::Dragon),
-            16 => Some(Self::Dark),
-            17 => Some(Self::Fairy),
-
-            99 => Some(Self::Stellar),
-            _ => None,
-        }
-    }
-}
-
-#[cfg(feature = "wasm")]
-impl From<TeraType> for TeraTypeWasm {
-    fn from(value: TeraType) -> Self {
-        match value {
-            TeraType::Stellar => Self::Stellar,
-            TeraType::Standard(pkm_type) => Self::from_byte(pkm_type as u8)
-                .expect("all valid u8 representations of TeraType are valid for TeraTypeWasm"),
-        }
-    }
-}
-
-#[cfg(feature = "wasm")]
-impl From<TeraTypeWasm> for TeraType {
-    fn from(value: TeraTypeWasm) -> Self {
-        match value {
-            TeraTypeWasm::Stellar => Self::Stellar,
-            standard_type => Self::from_byte_original(standard_type as u8).expect(
-                "all valid, non-Stellar u8 representations of TeraTypeWasm are valid for TeraType",
-            ),
-        }
     }
 }

--- a/pkm_rs_types/src/pkm_types.rs
+++ b/pkm_rs_types/src/pkm_types.rs
@@ -243,7 +243,8 @@ pub enum TeraTypeWasm {
     Dragon,
     Dark,
     Fairy,
-    Stellar,
+
+    Stellar = 99,
 }
 
 #[cfg(feature = "wasm")]
@@ -269,6 +270,8 @@ impl TeraTypeWasm {
             15 => Some(Self::Dragon),
             16 => Some(Self::Dark),
             17 => Some(Self::Fairy),
+
+            99 => Some(Self::Stellar),
             _ => None,
         }
     }

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -37,6 +37,7 @@ import {
   SpeciesForm,
   SpeciesLookup,
   Tag,
+  TeraType,
   TrainerData,
   TrainerMemory,
   updatePidIfWouldBecomeShinyGen345,
@@ -911,7 +912,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
       this.gameOfOriginBattle = otherGameOfOriginBattle
     }
 
-    if (other.teraTypeOverride !== undefined && this.teraTypeOverride !== other.teraTypeOverride) {
+    if (!teraTypesEqual(this.teraTypeOverride, other.teraTypeOverride)) {
       updates.push(syncUpdate('teraTypeOverride', this.teraTypeOverride, other.teraTypeOverride))
       this.teraTypeOverride = other.teraTypeOverride
     }
@@ -1171,4 +1172,15 @@ function objectsEqual(object1: IndexableObject, object2: IndexableObject) {
 
 function isObject(object: unknown): object is IndexableObject {
   return object !== null && typeof object === 'object'
+}
+
+function teraTypesEqual(tt1: Option<TeraType>, tt2: Option<TeraType>) {
+  switch (tt1) {
+    case undefined:
+      return tt2 === undefined
+    case 'Stellar':
+      return tt2 === 'Stellar'
+    default:
+      return isObject(tt2) && tt1.Standard === tt2.Standard
+  }
 }

--- a/src/core/pkm/PK9.ts
+++ b/src/core/pkm/PK9.ts
@@ -20,7 +20,7 @@ import {
   PkmFormat,
   PokeDate,
   SpeciesLookup,
-  TeraTypeWasm,
+  TeraType,
   TrainerMemory,
 } from '@pkm-rs/pkg'
 import { PkmConstructorOptions } from './PKM'
@@ -319,14 +319,14 @@ export default class PK9 {
   get teraTypeOriginal() {
     return this.inner.teraTypeOriginal
   }
-  set teraTypeOriginal(value: TeraTypeWasm) {
+  set teraTypeOriginal(value: TeraType) {
     this.inner.teraTypeOriginal = value
   }
 
   get teraTypeOverride() {
     return this.inner.teraTypeOverride
   }
-  set teraTypeOverride(value: Option<TeraTypeWasm>) {
+  set teraTypeOverride(value: Option<TeraType>) {
     this.inner.teraTypeOverride = value
   }
 

--- a/src/core/pkm/__test__/Ohpkm.test.ts
+++ b/src/core/pkm/__test__/Ohpkm.test.ts
@@ -452,6 +452,30 @@ describe('gen 3 ability during OHPKM conversion', () => {
   })
 })
 
+describe('OHPKM game data sync', () => {
+  test('Tera type is updated (non-stellar)', () => {
+    const original = OHPKM.defaultWithSpecies(NationalDex.Pikachu, 0)
+    const converted = R.assert(PK9.fromOhpkm(original, ConvertStrategies.getDefault()))
+
+    converted.teraTypeOverride = { Standard: 'Bug' }
+
+    original.syncWithGameData(converted)
+
+    expect(original.teraTypeOverride).toEqual({ Standard: 'Bug' })
+  })
+
+  test('Tera type is updated (stellar)', () => {
+    const original = OHPKM.defaultWithSpecies(NationalDex.Pikachu, 0)
+    const converted = R.assert(PK9.fromOhpkm(original, ConvertStrategies.getDefault()))
+
+    converted.teraTypeOverride = 'Stellar'
+
+    original.syncWithGameData(converted)
+
+    expect(original.teraTypeOverride).toEqual('Stellar')
+  })
+})
+
 function diffSpans(
   a: Uint8Array,
   b: Uint8Array,

--- a/src/core/pkm/util/pkmInterface.ts
+++ b/src/core/pkm/util/pkmInterface.ts
@@ -14,6 +14,7 @@ import {
   NatureIndex,
   ShinyLeaves,
   StatsPreSplit,
+  TeraType,
   TrainerMemory,
 } from '@pkm-rs/pkg'
 import * as types from '../../util/types'
@@ -122,8 +123,8 @@ export interface AllPKMFields {
   superTrainingDistFlags?: number
   superTrainingFlags?: number
   tags?: MonTag[]
-  teraTypeOriginal?: number
-  teraTypeOverride?: number
+  teraTypeOriginal?: TeraType
+  teraTypeOverride?: TeraType
   tmFlagsBDSP?: Uint8Array
   tmFlagsLza?: Uint8Array
   tmFlagsLzaDlc?: Uint8Array

--- a/src/ui/columns/ohpkm.tsx
+++ b/src/ui/columns/ohpkm.tsx
@@ -64,7 +64,10 @@ export default function useOhpkmColumns(
       name: 'Type 1',
       width: '3.5rem',
       sortFunction: stringSorter((mon) => mon.metadata?.type1),
-      renderValue: (mon) => <TypeIcon size="1.5rem" typeIndex={mon.metadata?.type1Index} />,
+      renderValue: (mon) =>
+        mon.metadata?.type1Index ? (
+          <TypeIcon size="1.5rem" typeIndex={mon.metadata?.type1Index} />
+        ) : null,
       getFilterValue: (mon) => mon.metadata?.type1 || 'Unknown',
       cellClass: 'centered-cell',
     },

--- a/src/ui/components/pokemon/TypeIcon.tsx
+++ b/src/ui/components/pokemon/TypeIcon.tsx
@@ -11,7 +11,7 @@ interface TypeIconProps {
 }
 
 const TypeIcon = (props: TypeIconProps) => {
-  const type = props.typeIndex ? teraTypeStringFromIndex(props.typeIndex) : props.type
+  const type = props.typeIndex !== undefined ? teraTypeStringFromIndex(props.typeIndex) : props.type
 
   return (
     type && (

--- a/src/ui/components/pokemon/TypeIcon.tsx
+++ b/src/ui/components/pokemon/TypeIcon.tsx
@@ -1,29 +1,49 @@
 import { teraTypeStringFromIndex } from '@openhome-core/resources'
 import { getPublicImageURL, getTypeIconPath } from '@openhome-ui/images/images'
-import { PkmType } from '@pkm-rs/pkg'
+import { PkmType, TeraType } from '@pkm-rs/pkg'
 import './style.css'
 
-interface TypeIconProps {
-  type?: PkmType
-  typeIndex?: number
+type TypeIconProps = {
   border?: boolean
   size?: number | string
-}
+} & (
+  | {
+      type: PkmType
+      typeIndex?: undefined
+      teraType?: undefined
+    }
+  | {
+      type?: undefined
+      typeIndex: number
+      teraType?: undefined
+    }
+  | {
+      type?: undefined
+      typeIndex?: undefined
+      teraType: TeraType
+    }
+)
 
 const TypeIcon = (props: TypeIconProps) => {
-  const type = props.typeIndex !== undefined ? teraTypeStringFromIndex(props.typeIndex) : props.type
+  let type: string
+
+  if (props.teraType) {
+    type = props.teraType === 'Stellar' ? 'Stellar' : props.teraType.Standard
+  } else if (props.typeIndex !== undefined) {
+    type = teraTypeStringFromIndex(props.typeIndex)
+  } else {
+    type = props.type
+  }
 
   return (
-    type && (
-      <img
-        className={props.border ? 'type-icon-border' : ''}
-        title={`${type} type`}
-        draggable={false}
-        alt={`${type} type`}
-        style={{ height: props.size ?? 24, width: props.size ?? 24 }}
-        src={getPublicImageURL(getTypeIconPath(type))}
-      />
-    )
+    <img
+      className={props.border ? 'type-icon-border' : ''}
+      title={`${type} type`}
+      draggable={false}
+      alt={`${type} type`}
+      style={{ height: props.size ?? 24, width: props.size ?? 24 }}
+      src={getPublicImageURL(getTypeIconPath(type))}
+    />
   )
 }
 

--- a/src/ui/pokemon-details/tabs/OtherTab.tsx
+++ b/src/ui/pokemon-details/tabs/OtherTab.tsx
@@ -520,19 +520,19 @@ function TeraTypeData(props: { mon: PKMInterfaceTera }) {
   const { mon } = props
 
   const currentTeraType = useMemo(
-    () => (mon.teraTypeOverride <= 18 ? mon.teraTypeOverride : mon.teraTypeOriginal),
+    () => (mon.teraTypeOverride !== 19 ? mon.teraTypeOverride : mon.teraTypeOriginal),
     [mon.teraTypeOriginal, mon.teraTypeOverride]
   )
 
   const previousTeraType = useMemo(
-    () => (mon.teraTypeOverride <= 18 ? mon.teraTypeOriginal : undefined),
+    () => (mon.teraTypeOverride !== 19 ? mon.teraTypeOriginal : undefined),
     [mon.teraTypeOriginal, mon.teraTypeOverride]
   )
 
   return (
     <AttributeRow label="Tera Type">
       <TypeIcon typeIndex={currentTeraType} />
-      {previousTeraType && (
+      {previousTeraType !== undefined && (
         <>
           <div>(originally </div>
           <TypeIcon typeIndex={previousTeraType} />

--- a/src/ui/pokemon-details/tabs/OtherTab.tsx
+++ b/src/ui/pokemon-details/tabs/OtherTab.tsx
@@ -47,9 +47,8 @@ import DynamaxLevel from '@openhome-ui/components/pokemon/DynamaxLevel'
 import GenderIcon from '@openhome-ui/components/pokemon/GenderIcon'
 import ShinyLeavesDisplay from '@openhome-ui/components/pokemon/ShinyLeaves'
 import TypeIcon from '@openhome-ui/components/pokemon/TypeIcon'
-import { Generation, Language, OriginGames, Pokerus, StatsPreSplit } from '@pkm-rs/pkg'
+import { Generation, Language, OriginGames, Pokerus, StatsPreSplit, TeraType } from '@pkm-rs/pkg'
 import { Flex } from '@radix-ui/themes'
-import { useMemo } from 'react'
 
 const HECTOGRAMS_TO_POUNDS = 0.2204623
 const CENTIMETERS_TO_INCHES = 0.3937008
@@ -508,34 +507,27 @@ const OtherDisplay = (props: { mon: PKMInterface }) => {
 export default OtherDisplay
 
 type PKMInterfaceTera = PKMInterface & {
-  teraTypeOriginal: number
-  teraTypeOverride: number
+  teraTypeOriginal: TeraType
+  teraTypeOverride?: TeraType
 }
 
 function hasTeraTypes(mon: PKMInterface): mon is PKMInterfaceTera {
-  return mon.teraTypeOriginal !== undefined && mon.teraTypeOverride !== undefined
+  return mon.teraTypeOriginal !== undefined
 }
 
 function TeraTypeData(props: { mon: PKMInterfaceTera }) {
   const { mon } = props
 
-  const currentTeraType = useMemo(
-    () => (mon.teraTypeOverride !== 19 ? mon.teraTypeOverride : mon.teraTypeOriginal),
-    [mon.teraTypeOriginal, mon.teraTypeOverride]
-  )
-
-  const previousTeraType = useMemo(
-    () => (mon.teraTypeOverride !== 19 ? mon.teraTypeOriginal : undefined),
-    [mon.teraTypeOriginal, mon.teraTypeOverride]
-  )
+  const currentTeraType = mon.teraTypeOverride ?? mon.teraTypeOriginal
+  const previousTeraType = mon.teraTypeOverride ? mon.teraTypeOriginal : undefined
 
   return (
     <AttributeRow label="Tera Type">
-      <TypeIcon typeIndex={currentTeraType} />
+      <TypeIcon teraType={currentTeraType} />
       {previousTeraType !== undefined && (
         <>
           <div>(originally </div>
-          <TypeIcon typeIndex={previousTeraType} />
+          <TypeIcon teraType={previousTeraType} />
           <div>)</div>
         </>
       )}


### PR DESCRIPTION
**Description**

- The Tera Type type for the JavaScript side was using the incorrect value for Stellar Tera, which would throw an error when trying to open a save file where a tracked Pokémon has the stellar tera type

**Issue**

Fixes #894 
