### PR TITLE
[MISC] Misc fixes + improvements

### DIFF
--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -564,6 +564,10 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
     )
   }
 
+  get tmMovesLza() {
+    return [...this.tmMovesLzaBase, ...this.tmMovesLzaDlc]
+  }
+
   get plusMovesLza() {
     return this.plusMoveFlags?.getMoveIds() ?? []
   }
@@ -578,7 +582,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
     return this.tutorFlagsLA ? movesFromLaTutorFlags(this.tutorFlagsLA) : []
   }
 
-  get tmMovesSvBaseGame() {
+  get tmMovesSv() {
     return this.tmFlagsSV ? movesFromSvTmFlags(this.tmFlagsSV) : []
   }
 

--- a/src/core/pkm/PA8.ts
+++ b/src/core/pkm/PA8.ts
@@ -1,5 +1,6 @@
 import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import { ModernRibbons } from '@openhome-core/resources'
+import { movesFromLaTutorFlags } from '@openhome-core/resources/moves/flags'
 import * as byteLogic from '@openhome-core/util/byteLogic'
 import { Errorable, Option, R } from '@openhome-core/util/functional'
 import { FourMoves } from '@openhome-core/util/types'
@@ -474,6 +475,10 @@ export default class PA8 {
 
     const masteredAtLevel = getMoveMasteredLevelLa(this.nationalDex, this.formIndex, moveId)
     return masteredAtLevel !== undefined && this.level >= masteredAtLevel
+  }
+
+  get tutorMovesLa() {
+    return this.tutorFlagsLA ? movesFromLaTutorFlags(this.tutorFlagsLA) : []
   }
 
   public getStats() {

--- a/src/core/pkm/PA9.ts
+++ b/src/core/pkm/PA9.ts
@@ -470,6 +470,10 @@ export default class PA9 {
     )
   }
 
+  get tmMovesLza() {
+    return [...this.tmMovesLzaBase, ...this.tmMovesLzaDlc]
+  }
+
   get plusMovesLza() {
     return this.plusMoveFlags?.getMoveIds() ?? []
   }

--- a/src/core/pkm/PK9.ts
+++ b/src/core/pkm/PK9.ts
@@ -1,5 +1,6 @@
 import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import { ModernRibbons } from '@openhome-core/resources'
+import { movesFromSvTmFlags } from '@openhome-core/resources/moves/flags'
 import { Errorable, Option, R } from '@openhome-core/util/functional'
 import { FourMoves, PKMDate, Stats } from '@openhome-core/util/types'
 import {
@@ -514,12 +515,16 @@ export default class PK9 {
     this.inner.trainer_gender = value
   }
 
-  get tmFlagsBaseGame() {
+  get tmFlagsSvBase() {
     return this.inner.tmFlagsBaseGame
   }
 
-  get tmFlagsDlc() {
+  get tmFlagsSvDlc() {
     return this.inner.tmFlagsDlc
+  }
+
+  get tmMovesSv() {
+    return this.tmFlagsSvBase ? movesFromSvTmFlags(this.tmFlagsSvBase) : []
   }
 
   get homeTracker() {

--- a/src/core/pkm/util/pkmInterface.ts
+++ b/src/core/pkm/util/pkmInterface.ts
@@ -128,12 +128,11 @@ export interface AllPKMFields {
   teraTypeOriginal?: TeraType
   teraTypeOverride?: TeraType
   tmFlagsLzaBase?: Uint8Array
-  tmMovesLzaBase?: Move[]
   tmFlagsLzaDlc?: Uint8Array
-  tmMovesLzaDlc?: Move[]
+  tmMovesLza?: Move[]
   plusMoveFlags?: PlusMoveFlags
   tmFlagsSV?: Uint8Array
-  tmMovesSV?: Move[]
+  tmMovesSv?: Move[]
   tmFlagsSVDLC?: Uint8Array
   tmMovesSVDLC?: Move[]
   trFlagsSwSh?: Uint8Array

--- a/src/core/util/sort.ts
+++ b/src/core/util/sort.ts
@@ -99,12 +99,12 @@ export function booleanSorter<T>(func: (val: T) => boolean | undefined) {
   }
 }
 
-export function dayjsSorter<T>(func: (val: T) => Dayjs | undefined) {
+export function dayjsSorter<T>(func: (val: T) => Dayjs | undefined, recentFirst: boolean = false) {
   return (a: T, b: T) => {
     const dateA = func(a) ?? dayjs.unix(0)
     const dateB = func(b) ?? dayjs.unix(0)
 
-    return dateA.diff(dateB)
+    return recentFirst ? dateB.diff(dateA) : dateA.diff(dateB)
   }
 }
 

--- a/src/ui/App.css
+++ b/src/ui/App.css
@@ -218,11 +218,6 @@ img {
   }
 }
 
-div {
-  user-select: none;
-  -webkit-user-select: none !important;
-}
-
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
@@ -231,8 +226,6 @@ html,
 body,
 #root {
   height: 100%;
-  user-select: none;
-  -webkit-user-select: none !important;
   -webkit-user-drag: none !important;
   overflow: hidden;
 }

--- a/src/ui/columns/ohpkm.tsx
+++ b/src/ui/columns/ohpkm.tsx
@@ -65,13 +65,25 @@ export default function useOhpkmColumns(
     {
       key: 'type1',
       name: 'Type 1',
-      width: '3.5rem',
+      width: '4rem',
       sortFunction: stringSorter((mon) => mon.metadata?.type1),
       renderValue: (mon) =>
         mon.metadata?.type1Index !== undefined ? (
           <TypeIcon size="1.5rem" typeIndex={mon.metadata?.type1Index} />
         ) : null,
       getFilterValue: (mon) => mon.metadata?.type1 || 'Unknown',
+      cellClass: 'centered-cell',
+    },
+    {
+      key: 'type2',
+      name: 'Type 2',
+      width: '4rem',
+      sortFunction: stringSorter((mon) => mon.metadata?.type2),
+      renderValue: (mon) =>
+        mon.metadata?.type2Index !== undefined ? (
+          <TypeIcon size="1.5rem" typeIndex={mon.metadata?.type2Index} />
+        ) : null,
+      getFilterValue: (mon) => mon.metadata?.type2 || 'Unknown',
       cellClass: 'centered-cell',
     },
     {
@@ -209,7 +221,7 @@ export default function useOhpkmColumns(
     {
       key: 'level',
       name: 'Level',
-      width: '3rem',
+      width: '5rem',
       renderValue: (value) => value.getLevel(),
       getFilterValue: (mon) => getLevelRange(mon.getLevel()),
       getFilterValueDropdownPos: (filterValue) =>
@@ -220,7 +232,7 @@ export default function useOhpkmColumns(
     {
       key: 'hp',
       name: 'HP',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.hp.toString(),
       getFilterValue: (mon) => mon.stats.hp.toString(),
       sortFunction: numericSorter((mon) => mon.stats.hp),
@@ -230,7 +242,7 @@ export default function useOhpkmColumns(
     {
       key: 'atk',
       name: 'ATK',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.atk.toString(),
       getFilterValue: (mon) => mon.stats.atk.toString(),
       sortFunction: numericSorter((mon) => mon.stats.atk),
@@ -240,7 +252,7 @@ export default function useOhpkmColumns(
     {
       key: 'def',
       name: 'DEF',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.def.toString(),
       getFilterValue: (mon) => mon.stats.def.toString(),
       sortFunction: numericSorter((mon) => mon.stats.def),
@@ -250,7 +262,7 @@ export default function useOhpkmColumns(
     {
       key: 'spa',
       name: 'SPA',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.spa.toString(),
       getFilterValue: (mon) => mon.stats.spa.toString(),
       sortFunction: numericSorter((mon) => mon.stats.spa),
@@ -260,7 +272,7 @@ export default function useOhpkmColumns(
     {
       key: 'spd',
       name: 'SPD',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.spd.toString(),
       getFilterValue: (mon) => mon.stats.spd.toString(),
       sortFunction: numericSorter((mon) => mon.stats.spd),
@@ -270,7 +282,7 @@ export default function useOhpkmColumns(
     {
       key: 'spe',
       name: 'SPE',
-      width: '2.5rem',
+      width: '3.5rem',
       renderValue: (mon) => mon.stats.spe.toString(),
       getFilterValue: (mon) => mon.stats.spe.toString(),
       sortFunction: numericSorter((mon) => mon.stats.spe),

--- a/src/ui/columns/ohpkm.tsx
+++ b/src/ui/columns/ohpkm.tsx
@@ -5,6 +5,7 @@ import { Option } from '@openhome-core/util/functional'
 import {
   SortableColumn,
   booleanSorter,
+  dayjsSorter,
   gameOrPluginSorter,
   gameSorter,
   multiSorter,
@@ -22,6 +23,7 @@ import {
 } from '@openhome-ui/state-zustand/banks-and-boxes/store'
 import { Language, Lookup, OriginGames } from '@pkm-rs/pkg'
 import { useRef } from 'react'
+import { SelectColumn } from 'react-data-grid'
 
 export default function useOhpkmColumns(
   trackedMonsToRelease: OhpkmIdentifier[],
@@ -34,6 +36,7 @@ export default function useOhpkmColumns(
   trackedMonsRef.current = trackedMonsToRelease
 
   return [
+    { ...SelectColumn, minWidth: 36, width: undefined },
     {
       key: 'Pokémon',
       name: 'Mon',
@@ -156,6 +159,14 @@ export default function useOhpkmColumns(
         (mon) => mon.pluginOrigin
       ),
       cellClass: 'centered-cell',
+    },
+    {
+      key: 'started_tracking',
+      name: 'First Tracked',
+      width: '8rem',
+      renderValue: (value) => value.startedTrackingTimestamp?.format('MMM DD, YYYY'),
+      sortFunction: dayjsSorter((mon) => mon.startedTrackingTimestamp, true),
+      noFilter: true,
     },
     {
       key: 'trainerName',

--- a/src/ui/components/badge/Badge.tsx
+++ b/src/ui/components/badge/Badge.tsx
@@ -30,7 +30,7 @@ function colorByPercent(percent: number) {
   return 'hsl(204, 99%, 65%)'
 }
 
-function NumericalBadge({ value, percent, max: maxProp }: TopRightNumericalBadgeProps) {
+function NumericBadge({ value, percent, max: maxProp }: TopRightNumericalBadgeProps) {
   if (value === undefined) return null
 
   const color = colorByPercent(percent ? value : Math.min((value / maxProp) * 100, 100))
@@ -170,7 +170,7 @@ const Badge = {
   Gigantamax: GigantamaxBadge,
   HyperTrain: HyperTrainBadge,
   Image: ImageBadge,
-  Numerical: NumericalBadge,
+  Numeric: NumericBadge,
   Pokerus: PokerusBadge,
 }
 

--- a/src/ui/components/badge/TopRightBadge.tsx
+++ b/src/ui/components/badge/TopRightBadge.tsx
@@ -22,28 +22,28 @@ export function TopRightBadge({ mon, badgeType }: TopRightBadgeProps) {
     case 'Gender':
       return <GenderIcon gender={mon.gender} />
     case 'Level':
-      return <Badge.Numerical value={mon.getLevel()} max={MAX_LEVEL} />
+      return <Badge.Numeric value={mon.getLevel()} max={MAX_LEVEL} />
     case 'EVs (Total)':
       const evsTotal = Object.values(mon.evs ?? mon.evsG12 ?? {}).reduce((p, c) => p + c, 0)
-      return <Badge.Numerical value={evsTotal} max={EV_TOTAL_MAX} />
+      return <Badge.Numeric value={evsTotal} max={EV_TOTAL_MAX} />
     case 'EV (HP)':
-      return <Badge.Numerical value={mon.evs?.hp} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.hp} max={EV_STAT_MAX} />
     case 'EV (Attack)':
-      return <Badge.Numerical value={mon.evs?.atk} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.atk} max={EV_STAT_MAX} />
     case 'EV (Defense)':
-      return <Badge.Numerical value={mon.evs?.def} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.def} max={EV_STAT_MAX} />
     case 'EV (Special Attack)':
-      return <Badge.Numerical value={mon.evs?.spa} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.spa} max={EV_STAT_MAX} />
     case 'EV (Special Defense)':
-      return <Badge.Numerical value={mon.evs?.spd} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.spd} max={EV_STAT_MAX} />
     case 'EV (Speed)':
-      return <Badge.Numerical value={mon.evs?.spe} max={EV_STAT_MAX} />
+      return <Badge.Numeric value={mon.evs?.spe} max={EV_STAT_MAX} />
     case 'IVs/DVs (Percent)':
       const ivsOrDvsPercent = mon.ivs ? getIvsPercent(mon) : hasDvs(mon) ? getDvsPercent(mon) : 0
-      return <Badge.Numerical value={ivsOrDvsPercent} percent />
+      return <Badge.Numeric value={ivsOrDvsPercent} percent />
     case 'Perfect IVs Count':
       const perfectIvsCount = getPerfectIvsCount(mon)
-      return <Badge.Numerical value={perfectIvsCount} max={STAT_TYPE_COUNT} />
+      return <Badge.Numeric value={perfectIvsCount} max={STAT_TYPE_COUNT} />
     case 'Hyper Trained':
       return (
         <Badge.HyperTrain
@@ -55,7 +55,7 @@ export function TopRightBadge({ mon, badgeType }: TopRightBadgeProps) {
     case 'Most Recent Save':
       return mon instanceof OHPKM && <Badge.Game originGame={mon.mostRecentSaveWasm?.game} />
     case 'Ribbon Count':
-      return <Badge.Numerical value={mon.ribbons?.length} max={3} /> // TODO: better handle color for ribbon count
+      return <Badge.Numeric value={mon.ribbons?.length} max={3} /> // TODO: better handle color for ribbon count
     case 'Ball':
       return (
         mon.ball && (
@@ -68,6 +68,16 @@ export function TopRightBadge({ mon, badgeType }: TopRightBadgeProps) {
       return <Badge.Gigantamax showIf={mon.canGigantamax} />
     case 'Pokérus':
       return <Badge.Pokerus pokerusByte={mon.pokerusByte} showIf={true} />
+    case 'TR Count (Sword/Shield)':
+      return <Badge.Numeric value={mon.trMovesSwSh?.length} max={3} />
+    case 'Tutor Moves Count (Legends Arceus)':
+      return <Badge.Numeric value={mon.tutorMovesLa?.length} max={3} />
+    case 'TM Count (Scarlet/Violet)':
+      return <Badge.Numeric value={mon.tmMovesSv?.length} max={3} />
+    case 'TM Count (Legends Z-A)':
+      return <Badge.Numeric value={mon.tmMovesLza?.length} max={3} />
+    case 'Plus Moves Known':
+      return <Badge.Numeric value={mon.plusMoveFlags?.getMoveIds().length} max={3} />
     default:
       return null
   }

--- a/src/ui/components/components.css
+++ b/src/ui/components/components.css
@@ -264,7 +264,7 @@
 
   .rdg-row:not([aria-selected='true']):not(.selected-row) {
     &:hover {
-      background-color: var(--accent-a2);
+      background-color: var(--accent-3);
     }
   }
 }

--- a/src/ui/hooks/monDisplay.ts
+++ b/src/ui/hooks/monDisplay.ts
@@ -86,6 +86,11 @@ export const TopRightIndicatorTypes = [
   'Alpha',
   'Gigantamax',
   'Pokérus',
+  'TR Count (Sword/Shield)',
+  'Tutor Moves Count (Legends Arceus)',
+  'TM Count (Scarlet/Violet)',
+  'TM Count (Legends Z-A)',
+  'Plus Moves Known',
 ] as const
 
 export type TopRightBadgeType = (typeof TopRightIndicatorTypes)[number]

--- a/src/ui/pages/tracked/Gen345Lookup.tsx
+++ b/src/ui/pages/tracked/Gen345Lookup.tsx
@@ -1,13 +1,18 @@
 import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import { PluginIdentifier } from '@openhome-core/save/interfaces'
-import { gameOrPluginSorter, SortableColumn, stringSorter } from '@openhome-core/util/sort'
+import {
+  gameOrPluginSorter,
+  multiSorter,
+  numericSorter,
+  SortableColumn,
+  stringSorter,
+} from '@openhome-core/util/sort'
 import Badge from '@openhome-ui/components/badge/Badge'
 import PokemonIcon from '@openhome-ui/components/PokemonIcon'
 import SortableDataGrid from '@openhome-ui/components/SortableDataGrid'
 import { useLookups } from '@openhome-ui/state/lookups/useLookups'
 import { useOhpkmStore } from '@openhome-ui/state/ohpkm'
-import { OriginGames } from '@pkm-rs/pkg'
-
+import { Language, Lookup, OriginGames } from '@pkm-rs/pkg'
 type G345LookupRow = {
   gen345ID: string
   homeID: string
@@ -41,6 +46,14 @@ export default function Gen345Lookup({ onSelectMon }: Gen345LookupProps) {
           </button>
         ),
       cellClass: 'centered-cell',
+      sortFunction: multiSorter(
+        numericSorter((value) => value.homeMon?.nationalDex),
+        numericSorter((value) => value.homeMon?.formIndex)
+      ),
+      getFilterValue: (value) =>
+        value.homeMon?.nationalDex
+          ? Lookup.speciesName(value.homeMon?.nationalDex, Language.English)
+          : undefined,
     },
     {
       key: 'game',

--- a/src/ui/pokemon-details/tabs/OtherTab.tsx
+++ b/src/ui/pokemon-details/tabs/OtherTab.tsx
@@ -51,9 +51,8 @@ const OtherDisplay = (props: { mon: PKMInterface }) => {
 
   const trMovesSwSh = mon.trMovesSwSh
   const tutorMovesLa = mon.tutorMovesLa
-  const tmMovesSvBase = mon.tmMovesSV
-  const tmMovesLzaBase = mon.tmMovesLzaBase
-  const tmMovesLzaDlc = mon.tmMovesLzaDlc
+  const tmMovesSvBase = mon.tmMovesSv
+  const tmMovesLza = mon.tmMovesLza
   const plusMovesLza = Array.from(mon.plusMoveFlags?.getMoveIds() ?? []).map((id) => Moves[id])
 
   return (
@@ -284,57 +283,19 @@ const OtherDisplay = (props: { mon: PKMInterface }) => {
             ))}
           </AttributeRowExpand>
         )}
-        {/* {!isRestricted(
-          LA_TRANSFER_RESTRICTIONS,
-          mon.nationalDex,
-          mon.formIndex,
-          mon.extraFormIndex
-        ) &&
-          mon.tutorFlagsLA &&
-          getFlagsInArrayRange(mon.tutorFlagsLA, 0, 8).length > 0 && (
-            <AttributeRowExpand
-              summary="LA Tutor Moves"
-              value={`${getFlagsInArrayRange(mon.tutorFlagsLA, 0, 8).length} Tutor Moves`}
-            >
-              {getFlagsInArrayRange(mon.tutorFlagsLA, 0, 8).map((i) => (
-                <AttributeRow key={`la_tutor_${i + 1}`} label={`Tutor ${i + 1}`} indent={10}>
-                  {Moves[LATutorMoveIndexes[i]].name}
-                </AttributeRow>
-              ))}
-            </AttributeRowExpand>
-          )} */}
-        {/* {!isRestricted(
-          SV_TRANSFER_RESTRICTIONS_ID,
-          mon.nationalDex,
-          mon.formIndex,
-          mon.extraFormIndex
-        ) &&
-          mon.tmFlagsSV &&
-          getFlagsInArrayRange(mon.tmFlagsSV, 0, 22).length > 0 && (
-            <AttributeRowExpand
-              summary="SV TMs"
-              value={`${getFlagsInArrayRange(mon.tmFlagsSV, 0, 22).length} TMs`}
-            >
-              {getFlagsInArrayRange(mon.tmFlagsSV, 0, 22).map((i) => (
-                <AttributeRow key={`sv_tm_${i}`} label={`TM ${i}`} indent={10}>
-                  {Moves[SVTMMoveIndexes[i]].name}
-                </AttributeRow>
-              ))}
-            </AttributeRowExpand>
-          )} */}
-        {tmMovesLzaBase && (
-          <AttributeRowExpand summary="Legends Z-A Base TMs" value={tmMovesLzaBase.length}>
-            {tmMovesLzaBase.map((move) => (
-              <AttributeRow key={`lza_base_tm_${move.name}`} label={move.name} indent={10}>
+        {tmMovesSvBase && tmMovesSvBase.length > 0 && (
+          <AttributeRowExpand summary="S/V Base TMs" value={tmMovesSvBase.length}>
+            {tmMovesSvBase.map((move) => (
+              <AttributeRow key={`sv_base_tm_${move.name}`} label={move.name} indent={10}>
                 {move.name}
               </AttributeRow>
             ))}
           </AttributeRowExpand>
         )}
-        {tmMovesLzaDlc && (
-          <AttributeRowExpand summary="Legends Z-A DLC TMs" value={tmMovesLzaDlc.length}>
-            {tmMovesLzaDlc.map((move) => (
-              <AttributeRow key={`lza_dlc_tm_${move.name}`} label={move.name} indent={10}>
+        {tmMovesLza && (
+          <AttributeRowExpand summary="Legends Z-A TMs" value={tmMovesLza.length}>
+            {tmMovesLza.map((move) => (
+              <AttributeRow key={`lza_tm_${move.name}`} label={move.name} indent={10}>
                 {move.name}
               </AttributeRow>
             ))}


### PR DESCRIPTION
**Description**

- Re-added missing select and type 2 columns
- Fixed the SV TM field so it is now visible again
- Tracking grid has a "started tracking at" column
- Text can be selected again
- Top right indicator can now display:
  - SwSh TR count
  - LA Tutor move count
  - S/V TM count
  - LZA TM count
  - LZA Plus Move count

**Issue**

Fixes #917 
Part of #931 
