### PR TITLE
[CHORE/FIX] Openhome id improvement + performance bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
 name = "OpenHome"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "openhome_core"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "dirs",
@@ -2930,7 +2930,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pkm_rs"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "aes",
  "arbitrary-int",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "pkm_rs_derive"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "pkm_rs_resources"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "arbitrary-int",
  "getrandom 0.4.3",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "pkm_rs_types"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 dependencies = [
  "arbitrary-int",
  "chrono",

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.16.0
+VERSION=1.17.0-x-alpha.0
 
 .PHONY: help
 help: # Display this help.

--- a/openhome_core/Cargo.toml
+++ b/openhome_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openhome_core"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 edition = "2024"
 
 [dependencies]

--- a/openhome_core/src/data_controller.rs
+++ b/openhome_core/src/data_controller.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::fs::{self, DirEntry};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
@@ -159,6 +159,17 @@ pub trait DataController {
         } else {
             self.read_file_json(dir, &relative_path)
         }
+    }
+
+    fn list_directory<P>(&self, dir: DataDir, relative_path: P) -> Result<Vec<DirEntry>>
+    where
+        P: AsRef<Path>,
+    {
+        let absolute_path = self.absolute_path(dir, relative_path)?;
+        Ok(fs::read_dir(&absolute_path)
+            .map_err(|e| Error::file_access(&absolute_path, e))?
+            .filter_map(|r| r.ok())
+            .collect())
     }
 }
 

--- a/openhome_core/src/lookup.rs
+++ b/openhome_core/src/lookup.rs
@@ -1,18 +1,17 @@
 use std::collections::HashMap;
 
-use pkm_rs::ohpkm::OhpkmV2;
+use pkm_rs::ohpkm::{OhpkmV2, OpenHomeId};
 use serde::{Deserialize, Serialize};
 
 use crate::data_controller::{DataController, DataDir};
 use crate::error::Result;
 use crate::ohpkm_store::OhpkmBytesStore;
 
-type IdentifierLookup = HashMap<String, String>;
+type IdentifierLookup = HashMap<String, OpenHomeId>;
 
 pub const GEN12_FILENAME: &str = "gen12_lookup.json";
 pub const GEN345_FILENAME: &str = "gen345_lookup.json";
 
-#[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LookupState {
@@ -28,6 +27,10 @@ impl LookupState {
             gen_345: data_controller
                 .read_or_create_default_json_file(DataDir::Storage, GEN345_FILENAME)?,
         })
+    }
+
+    pub fn from_lookups(gen_12: IdentifierLookup, gen_345: IdentifierLookup) -> Self {
+        Self { gen_12, gen_345 }
     }
 
     pub fn write_to_files(&self, data_controller: &impl DataController) -> Result<()> {
@@ -63,5 +66,13 @@ impl LookupState {
         for ohpkm in ohpkms {
             self.gen_345.insert(ohpkm.gen_345_id(), ohpkm.openhome_id());
         }
+    }
+
+    pub fn gen_12_entries(&self) -> impl Iterator<Item = (String, OpenHomeId)> {
+        self.gen_12.clone().into_iter()
+    }
+
+    pub fn gen_345_entries(&self) -> impl Iterator<Item = (String, OpenHomeId)> {
+        self.gen_345.clone().into_iter()
     }
 }

--- a/openhome_core/src/ohpkm_store.rs
+++ b/openhome_core/src/ohpkm_store.rs
@@ -3,6 +3,7 @@ use crate::error::{Error, Result};
 use crate::util;
 use base64::prelude::*;
 use pkm_rs::ohpkm::OhpkmV2;
+use pkm_rs::ohpkm::OpenHomeId;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::num::NonZeroU64;
@@ -11,9 +12,9 @@ use std::time::{Duration, UNIX_EPOCH};
 use std::{collections::HashMap, fs};
 use tracing::warn;
 
-#[cfg_attr(feature = "desktop", derive(specta::Type))]
+// #[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Default, Serialize, Deserialize, Clone)]
-pub struct OhpkmBytesStore(HashMap<String, Vec<u8>>);
+pub struct OhpkmBytesStore(HashMap<OpenHomeId, Vec<u8>>);
 
 impl OhpkmBytesStore {
     fn load_from_directory(path: &Path) -> Result<Self> {
@@ -61,7 +62,7 @@ impl OhpkmBytesStore {
                     let errors_fixed_msgs: Vec<String> =
                         errors.into_iter().map(|e| e.to_string()).collect();
                     let errors_fixed_serialized = json!({"errors_fixed": errors_fixed_msgs});
-                    warn!(event = "ohpkm_errors_fixed", context = %errors_fixed_serialized, ohpkm_id = mon.openhome_id(), "Fixed Ohpkm {identifier} with nickname {}", mon.get_nickname());
+                    warn!(event = "ohpkm_errors_fixed", context = %errors_fixed_serialized, ohpkm_id = mon.openhome_id().to_string(), "Fixed Ohpkm {identifier} with nickname {}", mon.get_nickname());
                     *bytes = mon.to_bytes();
                 }
             }
@@ -98,7 +99,7 @@ impl OhpkmBytesStore {
     pub fn to_b64_map(&self) -> HashMap<String, String> {
         let mut output: HashMap<String, String> = HashMap::new();
         for (k, v) in self.0.clone() {
-            output.insert(k, BASE64_STANDARD.encode(v));
+            output.insert(k.to_string(), BASE64_STANDARD.encode(v));
         }
 
         output
@@ -108,23 +109,23 @@ impl OhpkmBytesStore {
         self.0
             .clone()
             .into_iter()
-            .map(|(k, v)| (k, BASE64_STANDARD.encode(v)))
+            .map(|(k, v)| (k.to_string(), BASE64_STANDARD.encode(v)))
             .collect()
     }
 
-    pub fn includes(&self, identifier: &str) -> bool {
+    pub fn includes(&self, identifier: &OpenHomeId) -> bool {
         self.0.contains_key(identifier)
     }
 
-    pub fn insert(&mut self, identifier: &str, bytes: &[u8]) {
+    pub fn insert(&mut self, identifier: &OpenHomeId, bytes: &[u8]) {
         self.0.insert(identifier.to_owned(), bytes.to_vec());
     }
 
-    pub fn remove(&mut self, identifier: &str) -> bool {
+    pub fn remove(&mut self, identifier: &OpenHomeId) -> bool {
         self.0.remove(identifier).is_some()
     }
 
-    pub fn all_entries(&self) -> impl Iterator<Item = (&String, &Vec<u8>)> {
+    pub fn all_entries(&self) -> impl Iterator<Item = (&OpenHomeId, &Vec<u8>)> {
         self.0.iter()
     }
 }

--- a/openhome_core/src/ohpkm_store.rs
+++ b/openhome_core/src/ohpkm_store.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, UNIX_EPOCH};
 use std::{collections::HashMap, fs};
 use tracing::warn;
 
-// #[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Default, Serialize, Deserialize, Clone)]
 pub struct OhpkmBytesStore(HashMap<OpenHomeId, Vec<u8>>);
 

--- a/openhome_core/src/pkm_storage.rs
+++ b/openhome_core/src/pkm_storage.rs
@@ -9,7 +9,6 @@ use uuid::Uuid;
 
 pub const BANKS_FILENAME: &str = "banks.json";
 
-#[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Default, Serialize, Deserialize, Clone)]
 pub struct StoredBankData {
     banks: Vec<Bank>,
@@ -48,7 +47,6 @@ fn default_id() -> Uuid {
     Uuid::new_v4()
 }
 
-#[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Bank {
     #[serde(default = "default_id")]
@@ -90,7 +88,6 @@ impl Default for Bank {
     }
 }
 
-#[cfg_attr(feature = "desktop", derive(specta::Type))]
 #[derive(Default, Serialize, Deserialize, Clone)]
 pub struct Box {
     #[serde(default = "default_id")]
@@ -129,4 +126,106 @@ pub fn write_banks(controller: &impl DataController, mut bank_data: StoredBankDa
     bank_data.reset_box_indices();
 
     controller.write_file_json(DataDir::Storage, BANKS_FILENAME, &bank_data)
+}
+
+#[cfg_attr(feature = "desktop", derive(specta::Type))]
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct StoredBankDataWasm {
+    banks: Vec<BankWasm>,
+    #[serde(default)]
+    current_bank: usize,
+}
+
+impl From<StoredBankDataWasm> for StoredBankData {
+    fn from(value: StoredBankDataWasm) -> Self {
+        Self {
+            banks: value.banks.into_iter().map(Bank::from).collect(),
+            current_bank: value.current_bank,
+        }
+    }
+}
+
+impl From<StoredBankData> for StoredBankDataWasm {
+    fn from(value: StoredBankData) -> Self {
+        Self {
+            banks: value.banks.into_iter().map(BankWasm::from).collect(),
+            current_bank: value.current_bank,
+        }
+    }
+}
+
+#[cfg_attr(feature = "desktop", derive(specta::Type))]
+#[derive(Serialize, Deserialize, Clone)]
+pub struct BankWasm {
+    #[serde(default = "default_id")]
+    id: Uuid,
+    name: Option<String>,
+    index: usize,
+    boxes: Vec<BoxWasm>,
+    #[serde(default)]
+    current_box: usize,
+}
+
+impl From<BankWasm> for Bank {
+    fn from(value: BankWasm) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            index: value.index,
+            boxes: value.boxes.into_iter().map(Box::from).collect(),
+            current_box: value.current_box,
+        }
+    }
+}
+
+impl From<Bank> for BankWasm {
+    fn from(value: Bank) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            index: value.index,
+            boxes: value.boxes.into_iter().map(BoxWasm::from).collect(),
+            current_box: value.current_box,
+        }
+    }
+}
+
+#[cfg_attr(feature = "desktop", derive(specta::Type))]
+#[derive(Default, Serialize, Deserialize, Clone)]
+pub struct BoxWasm {
+    #[serde(default = "default_id")]
+    pub id: Uuid,
+    pub name: Option<String>,
+    pub index: usize,
+    pub identifiers: HashMap<u8, String>,
+}
+
+impl From<BoxWasm> for Box {
+    fn from(value: BoxWasm) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            index: value.index,
+            identifiers: value
+                .identifiers
+                .into_iter()
+                .filter_map(|(key, value)| value.parse().map(|id| (key, id)).ok())
+                .collect(),
+        }
+    }
+}
+
+impl From<Box> for BoxWasm {
+    fn from(value: Box) -> Self {
+        Self {
+            id: value.id,
+            name: value.name,
+            index: value.index,
+            identifiers: value
+                .identifiers
+                .into_iter()
+                .map(|(key, value)| (key, value.to_string()))
+                .collect(),
+        }
+    }
 }

--- a/openhome_core/src/pkm_storage.rs
+++ b/openhome_core/src/pkm_storage.rs
@@ -2,6 +2,7 @@ use crate::{
     Result,
     data_controller::{DataController, DataDir},
 };
+use pkm_rs::ohpkm::OpenHomeId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -109,7 +110,7 @@ impl Box {
     }
 }
 
-pub type BoxIdentifiers = HashMap<u8, String>;
+pub type BoxIdentifiers = HashMap<u8, OpenHomeId>;
 
 pub fn load_banks(controller: &impl DataController) -> Result<StoredBankData> {
     let mut storage: StoredBankData =

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "productName": "OpenHome",
   "name": "openhome",
-  "version": "1.16.0",
+  "version": "1.17.0-x-alpha.0",
   "description": "A tool for moving Pokémon between game saves",
   "keywords": [
     "pokemon",

--- a/pkm_rs/Cargo.toml
+++ b/pkm_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkm_rs"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 authors = ["Andrew Benington"]
 edition = "2024"
 description = "Read/write Pokémon save files and .pkm files"

--- a/pkm_rs/src/ohpkm/convert/pk9.rs
+++ b/pkm_rs/src/ohpkm/convert/pk9.rs
@@ -11,6 +11,7 @@ use crate::gen8_swsh;
 use crate::gen9_sv::Pk9;
 use crate::ohpkm;
 use crate::ohpkm::OhpkmV2;
+use crate::ohpkm::id::OpenHomeId;
 use crate::ohpkm::v2_sections::ScarletVioletData;
 use crate::ohpkm::v2_sections::pkm_bytes::StoredPkmBytes;
 use crate::result::{Error, Result};
@@ -19,6 +20,12 @@ use crate::traits::HasSpeciesAndForm;
 impl OhpkmConvert for Pk9 {
     fn to_main_data(&self) -> ohpkm::v2_sections::MainDataV2 {
         ohpkm::v2_sections::MainDataV2 {
+            openhome_id: OpenHomeId::new(
+                self.species_and_form.into_inner().get_ndex(),
+                self.trainer_id,
+                self.secret_id,
+                self.personality_value,
+            ),
             personality_value: self.personality_value,
             encryption_constant: self.encryption_constant,
             species_and_form: self.species_and_form.into_inner(),

--- a/pkm_rs/src/ohpkm/id.rs
+++ b/pkm_rs/src/ohpkm/id.rs
@@ -1,0 +1,177 @@
+use std::{fmt::Display, str::FromStr};
+
+use arrayref::array_refs;
+use pkm_rs_resources::species::SpeciesForm;
+use pkm_rs_types::NationalDex;
+
+#[cfg(feature = "wasm")]
+use wasm_bindgen::prelude::*;
+
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, specta::Type)]
+pub struct OpenHomeId {
+    national_dex: u16,
+    trainer_id: u16,
+    secret_id: u16,
+    personality_value: u32,
+}
+
+impl OpenHomeId {
+    pub fn new(
+        national_dex: NationalDex,
+        trainer_id: u16,
+        secret_id: u16,
+        personality_value: u32,
+    ) -> Self {
+        let base_evolution = SpeciesForm::base_form(national_dex).get_base_evolution();
+        Self {
+            national_dex: base_evolution.get_ndex() as u16,
+            trainer_id,
+            secret_id,
+            personality_value,
+        }
+    }
+
+    /// Fails if any of the internal components are 0
+    pub fn try_from_bytes(bytes: &[u8; 10]) -> Option<Self> {
+        let (ndex_bytes, tid_bytes, sid_bytes, pid_bytes) = array_refs![bytes, 2, 2, 2, 4];
+
+        let national_dex = NationalDex::from_le_bytes(*ndex_bytes).ok()? as u16;
+        let trainer_id = u16::from_le_bytes(*tid_bytes);
+        let secret_id = u16::from_le_bytes(*sid_bytes);
+        let personality_value = u32::from_le_bytes(*pid_bytes);
+
+        if trainer_id == 0 || secret_id == 0 || personality_value == 0 {
+            None
+        } else {
+            Some(Self {
+                national_dex,
+                trainer_id,
+                secret_id,
+                personality_value,
+            })
+        }
+    }
+
+    pub fn to_bytes(self) -> [u8; 10] {
+        let mut bytes = [0u8; 10];
+        bytes[0..2].copy_from_slice(&self.national_dex.to_le_bytes());
+        bytes[2..4].copy_from_slice(&self.trainer_id.to_le_bytes());
+        bytes[4..6].copy_from_slice(&self.secret_id.to_le_bytes());
+        bytes[6..10].copy_from_slice(&self.personality_value.to_le_bytes());
+
+        bytes
+    }
+}
+
+#[cfg(feature = "wasm")]
+#[wasm_bindgen]
+#[allow(clippy::missing_const_for_fn)]
+impl OpenHomeId {
+    #[wasm_bindgen(constructor)]
+    pub fn new_wasm(
+        national_dex: NationalDex,
+        trainer_id: u16,
+        secret_id: u16,
+        personality_value: u32,
+    ) -> Self {
+        Self {
+            national_dex: national_dex as u16,
+            trainer_id,
+            secret_id,
+            personality_value,
+        }
+    }
+
+    #[wasm_bindgen(js_name = toString)]
+    pub fn to_string_wasm(&self) -> String {
+        self.to_string()
+    }
+}
+
+impl Display for OpenHomeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:04}-{:04x}{:04x}-{:08x}",
+            self.national_dex, self.trainer_id, self.secret_id, self.personality_value,
+        )
+    }
+}
+
+impl Default for OpenHomeId {
+    fn default() -> Self {
+        Self {
+            national_dex: NationalDex::default() as u16,
+            trainer_id: Default::default(),
+            secret_id: Default::default(),
+            personality_value: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ParseOpenHomeIdError {
+    InvalidFormat,
+}
+
+impl Display for ParseOpenHomeIdError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid OpenHomeId format")
+    }
+}
+
+impl std::error::Error for ParseOpenHomeIdError {}
+
+impl FromStr for OpenHomeId {
+    type Err = ParseOpenHomeIdError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split('-').collect();
+        if parts.len() < 3 {
+            return Err(ParseOpenHomeIdError::InvalidFormat);
+        }
+
+        let national_dex = parts[0]
+            .parse::<u16>()
+            .map_err(|_| ParseOpenHomeIdError::InvalidFormat)?;
+
+        // middle segment is trainer_id (4 hex chars) + secret_id (4 hex chars)
+        if parts[1].len() < 8 {
+            return Err(ParseOpenHomeIdError::InvalidFormat);
+        }
+        let trainer_id = u16::from_str_radix(&parts[1][0..4], 16)
+            .map_err(|_| ParseOpenHomeIdError::InvalidFormat)?;
+        let secret_id = u16::from_str_radix(&parts[1][4..8], 16)
+            .map_err(|_| ParseOpenHomeIdError::InvalidFormat)?;
+
+        let personality_value =
+            u32::from_str_radix(parts[2], 16).map_err(|_| ParseOpenHomeIdError::InvalidFormat)?;
+
+        Ok(OpenHomeId {
+            national_dex,
+            trainer_id,
+            secret_id,
+            personality_value,
+        })
+    }
+}
+
+impl serde::Serialize for OpenHomeId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_string().serialize(serializer)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for OpenHomeId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<OpenHomeId>().map_err(serde::de::Error::custom)
+    }
+}

--- a/pkm_rs/src/ohpkm/id.rs
+++ b/pkm_rs/src/ohpkm/id.rs
@@ -134,6 +134,7 @@ impl FromStr for OpenHomeId {
 
         let national_dex = parts[0]
             .parse::<u16>()
+            .map(national_dex_base_evo)
             .map_err(|_| ParseOpenHomeIdError::InvalidFormat)?;
 
         // middle segment is trainer_id (4 hex chars) + secret_id (4 hex chars)
@@ -154,6 +155,16 @@ impl FromStr for OpenHomeId {
             secret_id,
             personality_value,
         })
+    }
+}
+
+fn national_dex_base_evo(raw: u16) -> u16 {
+    if let Ok(national_dex) = NationalDex::try_from(raw) {
+        SpeciesForm::base_form(national_dex)
+            .get_base_evolution()
+            .get_ndex() as u16
+    } else {
+        raw
     }
 }
 

--- a/pkm_rs/src/ohpkm/mod.rs
+++ b/pkm_rs/src/ohpkm/mod.rs
@@ -4,6 +4,7 @@ use pkm_rs_resources::metadata_source::MetadataSource;
 mod convert;
 #[allow(deprecated)]
 mod deprecated;
+mod id;
 mod issues;
 mod v2;
 mod v2_sections;
@@ -12,6 +13,7 @@ pub mod extra_form;
 pub mod v1;
 
 pub use convert::OhpkmConvert;
+pub use id::OpenHomeId;
 pub use v2::OhpkmV2;
 
 #[cfg(feature = "wasm")]

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -241,13 +241,18 @@ type DataUpdated = bool;
 
 impl OhpkmV2 {
     pub fn convert_without_backup<PKM: OhpkmConvert>(other: &PKM) -> Self {
-        Self {
+        let mut ohpkm = Self {
             main_data: other.to_main_data(),
             gen67_data: other.to_gen_67_data(),
             swsh_data: other.to_swsh_data(),
             sv_data: other.to_sv_data(),
             ..Default::default()
-        }
+        };
+
+        ohpkm.regenerate_openhome_id();
+        ohpkm.sync_learned_moves();
+
+        ohpkm
     }
 
     pub fn convert_with_backup<PKM: OhpkmConvert>(
@@ -263,6 +268,15 @@ impl OhpkmV2 {
 
     pub const fn openhome_id(&self) -> OpenHomeId {
         self.main_data.openhome_id
+    }
+
+    pub fn regenerate_openhome_id(&mut self) {
+        self.main_data.openhome_id = OpenHomeId::new(
+            self.species_and_form().get_ndex(),
+            self.trainer_id(),
+            self.secret_id(),
+            self.personality_value(),
+        );
     }
 
     pub fn gen_345_id(&self) -> String {
@@ -2037,12 +2051,7 @@ impl OhpkmV2 {
 
     #[wasm_bindgen(js_name = regenerateOpenhomeId)]
     pub fn regenerate_openhome_id_js(&mut self) {
-        self.main_data.openhome_id = OpenHomeId::new(
-            self.species_and_form().get_ndex(),
-            self.trainer_id(),
-            self.secret_id(),
-            self.personality_value(),
-        );
+        self.regenerate_openhome_id();
     }
 
     #[wasm_bindgen(getter = gen345Identifier)]

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -2035,6 +2035,16 @@ impl OhpkmV2 {
         self.openhome_id().to_string()
     }
 
+    #[wasm_bindgen(js_name = regenerateOpenhomeId)]
+    pub fn regenerate_openhome_id_js(&mut self) {
+        self.main_data.openhome_id = OpenHomeId::new(
+            self.species_and_form().get_ndex(),
+            self.trainer_id(),
+            self.secret_id(),
+            self.personality_value(),
+        );
+    }
+
     #[wasm_bindgen(getter = gen345Identifier)]
     pub fn gen_345_id_js(&self) -> String {
         self.gen_345_id()

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -1601,11 +1601,9 @@ impl OhpkmV2 {
     }
 
     pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        let sectioned_data = SectionedData::<OhpkmSectionTag>::from_bytes(bytes)?;
+        let sectioned_data = SectionedData::<OhpkmSectionTag>::from_bytes(bytes, MAGIC_NUMBER)?;
 
-        if sectioned_data.magic_number != MAGIC_NUMBER {
-            return Err(Error::other("Bad magic number"));
-        } else if sectioned_data.version != 2 {
+        if sectioned_data.version != 2 {
             return Err(Error::other("Bad version number"));
         }
 
@@ -1644,11 +1642,9 @@ impl OhpkmV2 {
     }
 
     pub fn from_bytes_fixing_errors(bytes: &[u8]) -> Result<Self> {
-        let sectioned_data = SectionedData::<OhpkmSectionTag>::from_bytes(bytes)?;
+        let sectioned_data = SectionedData::<OhpkmSectionTag>::from_bytes(bytes, MAGIC_NUMBER)?;
 
-        if sectioned_data.magic_number != MAGIC_NUMBER {
-            return Err(Error::other("Bad magic number"));
-        } else if sectioned_data.version != 2 {
+        if sectioned_data.version != 2 {
             return Err(Error::other("Bad version number"));
         }
 

--- a/pkm_rs/src/ohpkm/v2.rs
+++ b/pkm_rs/src/ohpkm/v2.rs
@@ -10,6 +10,7 @@ use crate::ohpkm::OhpkmConvert;
 #[allow(deprecated)]
 use crate::ohpkm::deprecated::PastHandlerDataV1;
 use crate::ohpkm::extra_form::ExtraFormIndex;
+use crate::ohpkm::id::OpenHomeId;
 use crate::ohpkm::issues::OhpkmIssue;
 use crate::ohpkm::v1::OhpkmV1;
 use crate::ohpkm::v2_sections::pkm_bytes::{OriginalBackup, StoredPkmBytes, UnconvertedPkm};
@@ -260,8 +261,8 @@ impl OhpkmV2 {
         Ok(ohpkm)
     }
 
-    pub fn openhome_id(&self) -> String {
-        self.main_data.openhome_id()
+    pub const fn openhome_id(&self) -> OpenHomeId {
+        self.main_data.openhome_id
     }
 
     pub fn gen_345_id(&self) -> String {
@@ -2035,7 +2036,7 @@ impl OhpkmV2 {
 
     #[wasm_bindgen(getter = openhomeId)]
     pub fn openhome_id_js(&self) -> String {
-        self.openhome_id()
+        self.openhome_id().to_string()
     }
 
     #[wasm_bindgen(getter = gen345Identifier)]

--- a/pkm_rs/src/ohpkm/v2_sections/main_data.rs
+++ b/pkm_rs/src/ohpkm/v2_sections/main_data.rs
@@ -129,12 +129,21 @@ impl MainDataV2 {
     pub fn new(national_dex: u16, form_index: u16) -> Result<Self> {
         let species_and_form = SpeciesForm::new(national_dex, form_index)?;
         let national_dex = species_and_form.get_ndex();
-        Ok(Self {
+        let mut main_data = Self {
             species_and_form,
             language: Language::English,
             nickname: lookup::species_name(national_dex, Language::English).into(),
             ..Default::default()
-        })
+        };
+
+        main_data.openhome_id = OpenHomeId::new(
+            national_dex,
+            main_data.trainer_id,
+            main_data.secret_id,
+            main_data.personality_value,
+        );
+
+        Ok(main_data)
     }
 
     pub fn from_v1(old: crate::ohpkm::v1::OhpkmV1) -> Self {
@@ -680,7 +689,10 @@ impl DataSection for MainDataV2 {
 
         bytes[244..248].copy_from_slice(&self.form_argument.to_le_bytes());
         bytes[248] = ModernRibbon::to_affixed_byte(self.affixed_ribbon);
-        // gap: 249-263
+        // gap: 249
+        bytes[250..260].copy_from_slice(&self.openhome_id.to_bytes());
+        // gap: 260-263
+
         bytes[264..272].copy_from_slice(&self.extra_form.map_or(0, |f| f as u64).to_le_bytes());
         bytes[272..298].copy_from_slice(&self.trainer_name);
         bytes[298] = self.trainer_friendship;

--- a/pkm_rs/src/ohpkm/v2_sections/main_data.rs
+++ b/pkm_rs/src/ohpkm/v2_sections/main_data.rs
@@ -1,4 +1,5 @@
 use crate::ohpkm::extra_form::ExtraFormIndex;
+use crate::ohpkm::id::OpenHomeId;
 use crate::ohpkm::issues::OhpkmIssue;
 use crate::ohpkm::v2::OhpkmSectionTag;
 use crate::result::{Error, Result};
@@ -43,6 +44,7 @@ const MOVE_DATA_OFFSETS: MoveDataOffsets = MoveDataOffsets {
 #[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Debug, Default, Serialize, Clone, Copy, IsShiny4096)]
 pub struct MainDataV2 {
+    pub openhome_id: OpenHomeId,
     pub personality_value: u32,
     pub encryption_constant: u32,
     pub species_and_form: SpeciesForm,
@@ -138,6 +140,12 @@ impl MainDataV2 {
     pub fn from_v1(old: crate::ohpkm::v1::OhpkmV1) -> Self {
         let home_tracker_raw = u64::from_le_bytes(old.home_tracker);
         MainDataV2 {
+            openhome_id: OpenHomeId::new(
+                old.species_and_form.get_ndex(),
+                old.trainer_id,
+                old.secret_id,
+                old.personality_value,
+            ),
             encryption_constant: old.encryption_constant,
             species_and_form: old.species_and_form,
             held_item_index: old.held_item_index,
@@ -220,18 +228,6 @@ impl MainDataV2 {
 
     pub const fn national_dex(&self) -> NationalDex {
         self.species_and_form.get_ndex()
-    }
-
-    pub fn openhome_id(&self) -> String {
-        let base_mon = self.species_and_form.get_base_evolution();
-        format!(
-            "{:04}-{:04x}{:04x}-{:08x}-{:02x}",
-            base_mon.get_ndex(),
-            self.trainer_id,
-            self.secret_id,
-            self.personality_value,
-            self.game_of_origin as u8
-        )
     }
 
     pub const fn with_timestamp_if_missing(
@@ -435,17 +431,22 @@ impl DataSection for MainDataV2 {
 
         let home_tracker_raw = u64::from_le_bytes(bytes[172..180].try_into().unwrap());
 
+        let personality_value = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let trainer_id = u16::from_le_bytes(bytes[12..14].try_into().unwrap());
+        let secret_id = u16::from_le_bytes(bytes[14..16].try_into().unwrap());
+        let national_dex = NationalDex::from_le_bytes(bytes[8..10].try_into().unwrap())?;
+
         // try_into() will always succeed if the buffer range size is correct.
         // if incorrect, it is a fatal coding flaw and will always panic.
         let data = Self {
-            personality_value: u32::from_le_bytes(bytes[0..4].try_into().unwrap()),
+            personality_value,
             encryption_constant: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-            species_and_form: SpeciesForm::new(
-                u16::from_le_bytes(bytes[8..10].try_into().unwrap()),
+            species_and_form: SpeciesForm::new_valid_ndex(
+                national_dex,
                 u16::from_le_bytes(bytes[10..12].try_into().unwrap()),
             )?,
-            trainer_id: u16::from_le_bytes(bytes[12..14].try_into().unwrap()),
-            secret_id: u16::from_le_bytes(bytes[14..16].try_into().unwrap()),
+            trainer_id,
+            secret_id,
             exp: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
             ability_index: AbilityIndexBounded::try_from(u16::from_le_bytes(
                 bytes[20..22].try_into().unwrap(),
@@ -548,7 +549,11 @@ impl DataSection for MainDataV2 {
             language: Language::try_from(bytes[242])?,
             form_argument: u32::from_le_bytes(bytes[244..248].try_into().unwrap()),
             affixed_ribbon: ModernRibbon::from_affixed_byte(bytes[248]),
-            // gap: 249-263
+            // gap: 249
+            openhome_id: OpenHomeId::try_from_bytes(bytes[250..260].try_into().unwrap()).unwrap_or(
+                OpenHomeId::new(national_dex, trainer_id, secret_id, personality_value),
+            ),
+            // gap: 260-263
 
             // TODO: handle invalid values
             extra_form: u64::from_le_bytes(bytes[264..272].try_into().unwrap())
@@ -710,17 +715,28 @@ fn current_time_unix_seconds() -> NonZeroU64 {
 impl Randomize for MainDataV2 {
     fn randomized<R: rand::Rng>(rng: &mut R) -> Self {
         let species_and_form = SpeciesForm::randomized(rng);
+        let personality_value = u32::randomized(rng);
+        let trainer_id = u16::randomized(rng);
+        let secret_id = u16::randomized(rng);
+
         let ability_num = AbilityNumber::randomized(rng);
         let ability_index = species_and_form
             .get_forme_metadata()
             .get_ability(ability_num);
+
         Self {
-            personality_value: u32::randomized(rng),
+            openhome_id: OpenHomeId::new(
+                species_and_form.get_ndex(),
+                trainer_id,
+                secret_id,
+                personality_value,
+            ),
+            personality_value,
             encryption_constant: u32::randomized(rng),
             species_and_form,
             held_item_index: u16::randomized(rng),
-            trainer_id: u16::randomized(rng),
-            secret_id: u16::randomized(rng),
+            trainer_id,
+            secret_id,
             exp: u32::randomized(rng),
             ability_index,
             ability_num,

--- a/pkm_rs/src/sectioned_data.rs
+++ b/pkm_rs/src/sectioned_data.rs
@@ -107,6 +107,7 @@ pub enum Error {
         length: SectionLength,
         buffer_size: usize,
     },
+    BadMagicNumber,
 }
 
 impl Display for Error {
@@ -129,6 +130,7 @@ impl Display for Error {
                 f,
                 "section {section_name} out of bounds at offset {offset}/length {length}/buffer_size {buffer_size}"
             ),
+            Error::BadMagicNumber => f.write_str("data has incorrect magic number"),
         }
     }
 }
@@ -203,7 +205,7 @@ impl<Tag: SectionTag> SectionedData<Tag> {
         self
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+    pub fn from_bytes(bytes: &[u8], expected_magic_number: u32) -> Result<Self> {
         if bytes.len() <= HEADER_SIZE {
             return Err(Error::BufferTooShort {
                 field: String::from("Data Header"),
@@ -213,6 +215,10 @@ impl<Tag: SectionTag> SectionedData<Tag> {
         }
 
         let magic_number = u32::from_le_bytes(bytes[0..4].try_into().expect(EMERGENCY_BUFFER_MSG));
+        if expected_magic_number != magic_number {
+            return Err(Error::BadMagicNumber);
+        }
+
         let version = u16::from_le_bytes(bytes[4..6].try_into().expect(EMERGENCY_BUFFER_MSG));
         let section_count = u16::from_le_bytes(bytes[6..8].try_into().expect(EMERGENCY_BUFFER_MSG));
 

--- a/pkm_rs_derive/Cargo.toml
+++ b/pkm_rs_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkm_rs_derive"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 authors = ["Andrew Benington"]
 edition = "2024"
 description = "Macros for the pkm_rs crate"

--- a/pkm_rs_resources/Cargo.toml
+++ b/pkm_rs_resources/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkm_rs_resources"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 edition = "2024"
 description = "Resource data and associated types for the pkm_rs crate"
 repository = "https://github.com/andrewbenington/OpenHome"

--- a/pkm_rs_types/Cargo.toml
+++ b/pkm_rs_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkm_rs_types"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 edition = "2024"
 description = "Types and helper code for the pkm_rs crate"
 repository = "https://github.com/andrewbenington/OpenHome"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "OpenHome"
-version = "1.16.0"
+version = "1.17.0-x-alpha.0"
 description = "A tool for moving Pokémon between game saves"
 authors = ["Andrew Benington"]
 edition = "2024"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,7 @@ use crate::util::ImageResponse;
 use crate::{menu, util};
 use openhome_core::data_controller::{DataController, DataDir};
 use openhome_core::error::{Error, Result};
-use openhome_core::pkm_storage::StoredBankData;
+use openhome_core::pkm_storage::StoredBankDataWasm;
 use openhome_core::saves::{self, SaveFileSearch};
 use serde_json::Value;
 use std::fs;
@@ -250,17 +250,18 @@ pub async fn find_suggested_saves(
 
 #[tauri::command]
 #[specta::specta]
-pub fn load_banks(app_handle: tauri::AppHandle) -> CommandResult<StoredBankData> {
-    Ok(openhome_core::pkm_storage::load_banks(
-        &app_handle.controller(),
-    )?)
+pub fn load_banks(app_handle: tauri::AppHandle) -> CommandResult<StoredBankDataWasm> {
+    Ok(openhome_core::pkm_storage::load_banks(&app_handle.controller())?.into())
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn write_banks(app_handle: tauri::AppHandle, bank_data: StoredBankData) -> CommandResult<()> {
+pub fn write_banks(
+    app_handle: tauri::AppHandle,
+    bank_data: StoredBankDataWasm,
+) -> CommandResult<()> {
     Ok(openhome_core::pkm_storage::write_banks(
         &app_handle.controller(),
-        bank_data,
+        bank_data.into(),
     )?)
 }

--- a/src-tauri/src/deprecated/pre_1_5_0.rs
+++ b/src-tauri/src/deprecated/pre_1_5_0.rs
@@ -1,4 +1,5 @@
 use openhome_core::pkm_storage;
+use pkm_rs::ohpkm::OpenHomeId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -15,14 +16,13 @@ pub struct BoxPreV1_5_0 {
 
 impl BoxPreV1_5_0 {
     pub fn upgrade(self) -> pkm_storage::Box {
-        let mut identifiers: HashMap<u8, String> = HashMap::new();
+        let mut identifiers: HashMap<u8, OpenHomeId> = HashMap::new();
         for (index_str, identifier) in self.mon_identifiers_by_index {
-            match index_str.parse::<u8>() {
-                Ok(index) => {
-                    identifiers.insert(index, identifier);
-                }
-                Err(_) => continue,
-            }
+            if let Ok(index) = index_str.parse::<u8>()
+                && let Ok(openhome_id) = identifier.parse()
+            {
+                identifiers.insert(index, openhome_id);
+            };
         }
 
         pkm_storage::Box {

--- a/src-tauri/src/startup_config.rs
+++ b/src-tauri/src/startup_config.rs
@@ -47,6 +47,7 @@ pub fn get_data_dir_path(
 pub async fn change_data_dir(
     app_handle: tauri::AppHandle,
     startup_config_state: tauri::State<'_, StartupConfigState>,
+    should_move: bool, // if true, files in current dir are moved to the new one and deleted from the current one
 ) -> CommandResult<()> {
     let Some(selected_dir) = app_handle
         .dialog()
@@ -62,7 +63,7 @@ pub async fn change_data_dir(
         return Ok(());
     };
 
-    if !is_dir_empty_ignore_ds_store(selected_dir)? {
+    if should_move && !is_dir_empty_ignore_ds_store(selected_dir)? {
         return Err(Error::other(
             "Selected directory is not empty. Please select an empty directory.",
         )
@@ -71,7 +72,9 @@ pub async fn change_data_dir(
 
     let current_data_dir = controller.get_data_folder()?;
 
-    copy_all_directory_items(&current_data_dir, selected_dir)?;
+    if should_move {
+        copy_all_directory_items(&current_data_dir, selected_dir)?;
+    }
 
     let mut state = startup_config_state.lock()?;
 
@@ -79,22 +82,24 @@ pub async fn change_data_dir(
     state.update_data_dir(selected_dir);
     state.write_to_storage()?;
 
-    // if we fail to delete old files, log the error but don't abort the dir change process
-    let old_storage_dir = current_data_dir.join("storage");
-    if let Err(err) = fs::remove_dir_all(&old_storage_dir) {
-        eprintln!("Failed to delete old storage directory at {old_storage_dir:?}: {err}");
-    }
-    let old_plugins_dir = current_data_dir.join("plugins");
-    if old_plugins_dir.exists()
-        && let Err(err) = fs::remove_dir_all(&old_plugins_dir)
-    {
-        eprintln!("Failed to delete old plugins directory at {old_plugins_dir:?}: {err}");
-    }
-    let old_version_file = current_data_dir.join("version.txt");
-    if old_version_file.exists()
-        && let Err(err) = fs::remove_file(&old_version_file)
-    {
-        eprintln!("Failed to delete old version file at {old_version_file:?}: {err}");
+    if should_move {
+        // if we fail to delete old files, log the error but don't abort the dir change process
+        let old_storage_dir = current_data_dir.join("storage");
+        if let Err(err) = fs::remove_dir_all(&old_storage_dir) {
+            eprintln!("Failed to delete old storage directory at {old_storage_dir:?}: {err}");
+        }
+        let old_plugins_dir = current_data_dir.join("plugins");
+        if old_plugins_dir.exists()
+            && let Err(err) = fs::remove_dir_all(&old_plugins_dir)
+        {
+            eprintln!("Failed to delete old plugins directory at {old_plugins_dir:?}: {err}");
+        }
+        let old_version_file = current_data_dir.join("version.txt");
+        if old_version_file.exists()
+            && let Err(err) = fs::remove_file(&old_version_file)
+        {
+            eprintln!("Failed to delete old version file at {old_version_file:?}: {err}");
+        }
     }
 
     // restart the app for a fresh launch using the new data directory

--- a/src-tauri/src/synced_state/lookup.rs
+++ b/src-tauri/src/synced_state/lookup.rs
@@ -1,5 +1,7 @@
+use std::collections::HashMap;
+
 use openhome_core::lookup::LookupState;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::commands::{CommandError, CommandResult};
 use crate::synced_state;
@@ -12,8 +14,53 @@ impl synced_state::SyncedState for LookupState {
         self.union_with(other);
     }
 
-    fn to_command_response(&self) -> impl Clone + Serialize + tauri::ipc::IpcResponse {
-        self
+    fn to_command_response(&self) -> impl std::clone::Clone + Serialize + tauri::ipc::IpcResponse {
+        LookupStateStringIds::from_lookup_state(self)
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct LookupStateStringIds {
+    gen_12: HashMap<String, String>,
+    gen_345: HashMap<String, String>,
+}
+
+impl LookupStateStringIds {
+    pub fn from_lookup_state(other: &LookupState) -> Self {
+        Self {
+            gen_12: other
+                .gen_12_entries()
+                .map(|(g12_id, openhome_id)| (g12_id, openhome_id.to_string()))
+                .collect(),
+            gen_345: other
+                .gen_345_entries()
+                .map(|(g345_id, openhome_id)| (g345_id, openhome_id.to_string()))
+                .collect(),
+        }
+    }
+
+    pub fn into_lookup_state(self) -> LookupState {
+        LookupState::from_lookups(
+            self.gen_12
+                .into_iter()
+                .filter_map(|(g12_id, openhome_id)| {
+                    openhome_id
+                        .parse()
+                        .ok()
+                        .map(|parsed_oh_id| (g12_id, parsed_oh_id))
+                })
+                .collect(),
+            self.gen_345
+                .into_iter()
+                .filter_map(|(g345_id, openhome_id)| {
+                    openhome_id
+                        .parse()
+                        .ok()
+                        .map(|parsed_oh_id| (g345_id, parsed_oh_id))
+                })
+                .collect(),
+        )
     }
 }
 
@@ -21,8 +68,10 @@ impl synced_state::SyncedState for LookupState {
 #[specta::specta]
 pub fn get_lookups(
     synced_state: tauri::State<'_, synced_state::AllSyncedState>,
-) -> CommandResult<LookupState> {
-    Ok(synced_state.clone_lookups()?)
+) -> CommandResult<LookupStateStringIds> {
+    Ok(LookupStateStringIds::from_lookup_state(
+        &synced_state.clone_lookups()?,
+    ))
 }
 
 #[tauri::command]
@@ -30,12 +79,12 @@ pub fn get_lookups(
 pub fn add_to_lookups(
     app_handle: tauri::AppHandle,
     synced_state: tauri::State<'_, synced_state::AllSyncedState>,
-    new_entries: LookupState,
+    new_entries: LookupStateStringIds,
 ) -> CommandResult<()> {
     synced_state
         .lock()?
         .lookups
-        .update(&app_handle, new_entries)
+        .update(&app_handle, new_entries.into_lookup_state())
         .map_err(CommandError::from)
 }
 

--- a/src-tauri/src/synced_state/ohpkm_store.rs
+++ b/src-tauri/src/synced_state/ohpkm_store.rs
@@ -59,8 +59,8 @@ pub fn permanently_delete_ohpkms(
         .ohpkm_store
         .replace(&app_handle, |store| {
             let mut new_store = store.clone();
-            for identifier in &openhome_ids {
-                new_store.remove(identifier);
+            for identifier in openhome_ids.iter().filter_map(|id_str| id_str.parse().ok()) {
+                new_store.remove(&identifier);
             }
             new_store
         })?;

--- a/src-tauri/src/version.rs
+++ b/src-tauri/src/version.rs
@@ -1,15 +1,22 @@
 use crate::deprecated;
 use crate::util;
 use openhome_core::data_controller::{DataController, DataDir, MONS_V2_DIR};
+use openhome_core::lookup::GEN12_FILENAME;
+use openhome_core::lookup::GEN345_FILENAME;
+use openhome_core::lookup::LookupState;
 use openhome_core::pkm_storage::{Bank, StoredBankData};
 use openhome_core::{Error, Result};
+use pkm_rs::ohpkm::OpenHomeId;
 use pkm_rs::ohpkm::{OhpkmV2, v1::OhpkmV1};
 use semver::Version;
 use serde::Serialize;
+use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fs::DirEntry;
 use std::{fs, path::PathBuf};
 use strum::{self, EnumIter, IntoEnumIterator};
 use tracing::error;
+use tracing::warn;
 use tracing::{debug, info};
 
 const VERSION_FILE: &str = "version.txt";
@@ -176,6 +183,7 @@ pub enum SignificantUpdate {
     V1_15_1,
     V1_15_2,
     V1_16_0,
+    V1_17_0,
 }
 
 impl SignificantUpdate {
@@ -212,6 +220,7 @@ impl SignificantUpdate {
             Self::V1_15_1 => Version::parse("1.15.1"),
             Self::V1_15_2 => Version::parse("1.15.2"),
             Self::V1_16_0 => Version::parse("1.16.0"),
+            Self::V1_17_0 => Version::parse("1.17.0-x-alpha.0"),
         }
         .expect("all versions are valid semver")
     }
@@ -223,7 +232,7 @@ impl SignificantUpdate {
             Self::V1_8_0AlphaFeatureMessages => Ok(()),
             Self::V1_8_1 => handle_old_mons_directories_for_ohpkm_v2(data_controller),
             Self::V1_14_1 => update_convert_strat_json_dot_keys(data_controller),
-            Self::V1_16_0 => update_ohpkm_filenames_standard_format(data_controller),
+            Self::V1_17_0 => update_ohpkm_filenames_standard_format(data_controller),
             _ => Ok(()),
         }
     }
@@ -493,7 +502,54 @@ pub fn update_convert_strat_json_dot_keys(data_controller: &impl DataController)
 }
 
 fn update_ohpkm_filenames_standard_format(data_controller: &impl DataController) -> Result<()> {
+    let gen12_lookup_old: HashMap<String, String> = data_controller
+        .read_file_json_if_exists(DataDir::Storage, GEN12_FILENAME)
+        .transpose()?
+        .unwrap_or_default();
+
+    let gen345_lookup_old: HashMap<String, String> = data_controller
+        .read_file_json_if_exists(DataDir::Storage, GEN345_FILENAME)
+        .transpose()?
+        .unwrap_or_default();
+
+    let gen12_id_by_old_openhome_id: HashMap<String, String> = gen12_lookup_old
+        .into_iter()
+        .map(|(key, value)| (value, key))
+        .collect();
+
+    let gen345_id_by_old_openhome_id: HashMap<String, String> = gen345_lookup_old
+        .into_iter()
+        .map(|(key, value)| (value, key))
+        .collect();
+
+    let mut new_gen12_lookup: HashMap<String, OpenHomeId> = HashMap::new();
+    let mut new_gen345_lookup: HashMap<String, OpenHomeId> = HashMap::new();
+
     for dir_entry in data_controller.list_directory(DataDir::Storage, MONS_V2_DIR)? {
+        let path = dir_entry.path();
+        if path.extension().is_none_or(|ext| !ext.eq("ohpkm")) {
+            warn!(
+                "skipping file {}: no .ohpkm extension",
+                path.as_os_str().to_string_lossy()
+            );
+            continue;
+        }
+
+        let mon = OhpkmV2::from_bytes(&util::read_file_bytes(&path)?)
+            .map_err(|e| Error::file_malformed(&path, e))?;
+
+        if let Some(existing_openhome_id) = PathBuf::from(dir_entry.file_name())
+            .file_stem()
+            .and_then(OsStr::to_str)
+        {
+            if let Some(gen12_id) = gen12_id_by_old_openhome_id.get(existing_openhome_id) {
+                new_gen12_lookup.insert(gen12_id.clone(), mon.openhome_id());
+            }
+            if let Some(gen345_id) = gen345_id_by_old_openhome_id.get(existing_openhome_id) {
+                new_gen345_lookup.insert(gen345_id.clone(), mon.openhome_id());
+            }
+        }
+
         if let Err(err) = standardize_ohpkm_filename(&dir_entry) {
             error!(
                 "error renaming {}: {}",
@@ -505,6 +561,9 @@ fn update_ohpkm_filenames_standard_format(data_controller: &impl DataController)
             )
         }
     }
+
+    LookupState::from_lookups(new_gen12_lookup, new_gen345_lookup)
+        .write_to_files(data_controller)?;
 
     Ok(())
 }

--- a/src-tauri/src/version.rs
+++ b/src-tauri/src/version.rs
@@ -6,8 +6,10 @@ use openhome_core::{Error, Result};
 use pkm_rs::ohpkm::{OhpkmV2, v1::OhpkmV1};
 use semver::Version;
 use serde::Serialize;
+use std::fs::DirEntry;
 use std::{fs, path::PathBuf};
 use strum::{self, EnumIter, IntoEnumIterator};
+use tracing::error;
 use tracing::{debug, info};
 
 const VERSION_FILE: &str = "version.txt";
@@ -221,6 +223,7 @@ impl SignificantUpdate {
             Self::V1_8_0AlphaFeatureMessages => Ok(()),
             Self::V1_8_1 => handle_old_mons_directories_for_ohpkm_v2(data_controller),
             Self::V1_14_1 => update_convert_strat_json_dot_keys(data_controller),
+            Self::V1_16_0 => update_ohpkm_filenames_standard_format(data_controller),
             _ => Ok(()),
         }
     }
@@ -487,6 +490,45 @@ pub fn update_convert_strat_json_dot_keys(data_controller: &impl DataController)
     let fixed_json = convert_strats_json.replace(".", "__");
 
     data_controller.write_file_text(DATA_DIR, JSON_FILENAME, &fixed_json)
+}
+
+fn update_ohpkm_filenames_standard_format(data_controller: &impl DataController) -> Result<()> {
+    for dir_entry in data_controller.list_directory(DataDir::Storage, MONS_V2_DIR)? {
+        if let Err(err) = standardize_ohpkm_filename(&dir_entry) {
+            error!(
+                "error renaming {}: {}",
+                dir_entry
+                    .file_name()
+                    .into_string()
+                    .unwrap_or("(cannot decode filename)".to_owned()),
+                err
+            )
+        }
+    }
+
+    Ok(())
+}
+
+fn standardize_ohpkm_filename(dir_entry: &DirEntry) -> Result<()> {
+    let path = dir_entry.path();
+    let mon = OhpkmV2::from_bytes(&util::read_file_bytes(&path)?)
+        .map_err(|e| Error::file_malformed(&path, e))?;
+
+    let openhome_id_str = mon.openhome_id().to_string();
+    let filename = PathBuf::from(dir_entry.file_name());
+
+    if let Some(stem) = filename.file_stem()
+        && let Some(stem) = stem.to_str()
+        && stem == openhome_id_str
+    {
+        return Ok(());
+    }
+
+    fs::rename(
+        &path,
+        path.with_file_name(format!("{openhome_id_str}.ohpkm")),
+    )
+    .map_err(|e| Error::file_access(&path, e))
 }
 
 #[cfg(test)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OpenHome",
-  "version": "1.16.0",
+  "version": "1.17.0-x-alpha.0",
   "identifier": "OpenHome",
   "build": {
     "beforeDevCommand": "pnpm run dev",

--- a/src/core/backend/backendInterface.ts
+++ b/src/core/backend/backendInterface.ts
@@ -68,8 +68,10 @@ export default interface BackendInterface {
   addToOhpkmStore: (updates: OhpkmStore) => Promise<Errorable<null>>
   deleteHomeMons: (identifiers: string[]) => Promise<Errorable<null>>
 
-  /* prompt user to select new data directory location */
+  /* prompt user to select new data directory location, then restart using that location */
   promptChangeDataDir: () => Promise<Errorable<null>>
+  /* prompt user to select new data directory location, copy all data there, and restart using that location */
+  promptMoveDataDir: () => Promise<Errorable<null>>
   /* get the current data directory path */
   getDataDirPath: () => Promise<Errorable<string>>
 

--- a/src/core/pkm/Lookup.ts
+++ b/src/core/pkm/Lookup.ts
@@ -7,7 +7,7 @@ import {
   utf16StringToGen12,
 } from '@openhome-core/util/stringConversion'
 import { PKMFormeRef } from '@openhome-core/util/types'
-import { Language, MetadataSummaryLookup, OriginGame, OriginGames } from '@pkm-rs/pkg'
+import { Language, MetadataSummaryLookup, OpenHomeId, OriginGame, OriginGames } from '@pkm-rs/pkg'
 
 export type OhpkmIdentifier = string
 
@@ -47,12 +47,12 @@ function getHomeIdentifier(mon: HomeIdentifierDerivableMon): OhpkmIdentifier {
     throw Error(`Invalid dex/form: ${mon.nationalDex} / ${mon.formIndex}`)
   }
 
-  return `${baseEvolution.nationalDex.toString().padStart(4, '0')}-${bytesToString(
+  return new OpenHomeId(
+    baseEvolution.nationalDex,
     mon.trainerID,
-    2
-  ).concat(
-    bytesToString(mon.secretID ?? 0, 2)
-  )}-${bytesToString(mon.personalityValue ?? 0, 4)}-${bytesToString(mon.gameOfOrigin ?? -1, 1)}`
+    mon.secretID,
+    mon.personalityValue
+  ).toString()
 }
 
 export type Gen12Identifier = string

--- a/src/core/pkm/OHPKM.ts
+++ b/src/core/pkm/OHPKM.ts
@@ -169,9 +169,7 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
           Gender.Genderless
         this.nature = other.nature ?? NatureIndex.newFromModulo(other.exp)
 
-        if (other.personalityValue === undefined) {
-          this.personalityValue = this.generatePk3CompatiblePid()
-        }
+        this.personalityValue = this.generatePk3CompatiblePid()
       } else {
         this.abilityNum = other.abilityNum ?? 0
         this.gender =
@@ -358,6 +356,8 @@ export class OHPKM extends OhpkmV2Wasm implements PKMInterface {
       }
 
       this.populateLearnedMoves()
+      // because the ohpkm wasm struct is initialized with an empty byte array, this needs to be called to set the stored openhome ID (or it will remain the default 0001-00000000-00000000)
+      this.regenerateOpenhomeId()
     }
   }
 

--- a/src/core/pkm/__test__/Ohpkm.test.ts
+++ b/src/core/pkm/__test__/Ohpkm.test.ts
@@ -1,4 +1,4 @@
-import { PA8, PK2, PK3, PK4, PK7, PK8, PK9 } from '@openhome-core/pkm'
+import { PA8, PK3, PK4, PK7, PK8, PK9 } from '@openhome-core/pkm'
 import { NationalDex } from '@openhome-core/resources/consts/NationalDex'
 import { SwordShieldSave } from '@openhome-core/save/Gen89/SwordShieldSave'
 import PB8LUMI from '@openhome-core/save/luminescentplatinum/PB8LUMI'
@@ -155,19 +155,6 @@ describe('evolution and form change update ohpkm', async () => {
     expect(mrMimeOhpkm.nationalDex).toEqual(NationalDex.MrRime)
     expect(mrMimeOhpkm.formIndex).toEqual(0)
   })
-})
-
-test('Game Boy Pokemon in the same evolution family have distinct OpenHome IDs', () => {
-  const bytes = new Uint8Array(fs.readFileSync(pkmTestFilePath('pk2', 'hooh.pk2')))
-  const abra = PK2.fromBytes(bytes.buffer)
-  const kadabra = PK2.fromBytes(bytes.buffer.slice(0))
-
-  abra.nationalDex = NationalDex.Abra
-  kadabra.nationalDex = NationalDex.Kadabra
-
-  expect(OHPKM.fromMonUnknownSave(abra).openhomeId).not.toEqual(
-    OHPKM.fromMonUnknownSave(kadabra).openhomeId
-  )
 })
 
 describe('plugin form persistence', () => {

--- a/src/core/tauri/backend.ts
+++ b/src/core/tauri/backend.ts
@@ -106,8 +106,10 @@ export const TauriBackend: BackendInterface = {
     )
   },
 
-  /* prompt user to select new data directory location */
-  promptChangeDataDir: Commands.changeDataDir,
+  /* prompt user to select new data directory location, then restart using that location */
+  promptChangeDataDir: () => Commands.changeDataDir(false),
+  /* prompt user to select new data directory location, copy all data there, and restart using that location */
+  promptMoveDataDir: () => Commands.changeDataDir(true),
   /* get the current data directory path */
   getDataDirPath: Commands.getDataDirPath,
 

--- a/src/core/tauri/backend.ts
+++ b/src/core/tauri/backend.ts
@@ -30,7 +30,7 @@ import {
   LogFilterJs,
   LogFilter as LogFilterRust,
   LogsResponse as LogsResponseRust,
-  StoredBankData as StoredBankDataRust,
+  StoredBankDataWasm as StoredBankDataRust,
 } from './spectaCommands'
 
 async function pathDataFromRaw(raw: string): Promise<PathData> {

--- a/src/core/tauri/spectaCommands.ts
+++ b/src/core/tauri/spectaCommands.ts
@@ -126,7 +126,7 @@ export const commands = {
       else return { status: 'error', error: e as any }
     }
   },
-  async loadBanks(): Promise<Result<StoredBankData, CommandError>> {
+  async loadBanks(): Promise<Result<StoredBankDataWasm, CommandError>> {
     try {
       return { status: 'ok', data: await TAURI_INVOKE('load_banks') }
     } catch (e) {
@@ -134,7 +134,7 @@ export const commands = {
       else return { status: 'error', error: e as any }
     }
   },
-  async writeBanks(bankData: StoredBankData): Promise<Result<null, CommandError>> {
+  async writeBanks(bankData: StoredBankDataWasm): Promise<Result<null, CommandError>> {
     try {
       return { status: 'ok', data: await TAURI_INVOKE('write_banks', { bankData }) }
     } catch (e) {
@@ -302,14 +302,14 @@ export type AppStateInner = {
   new_features_since_update: UpdateFeatures[]
   transaction: TransactionState
 }
-export type Bank = {
+export type BankWasm = {
   id?: string
   name: string | null
   index: number
-  boxes: Box[]
+  boxes: BoxWasm[]
   current_box?: number
 }
-export type Box = {
+export type BoxWasm = {
   id?: string
   name: string | null
   index: number
@@ -383,7 +383,7 @@ export type SaveRef = {
   valid: boolean
   pluginIdentifier: PluginIdentifier | null
 }
-export type StoredBankData = { banks: Bank[]; current_bank?: number }
+export type StoredBankDataWasm = { banks: BankWasm[]; current_bank?: number }
 export type TransactionState = { open_transaction: boolean; temp_files: string[] }
 export type UpdateFeatures = { version: string; feature_messages: string[] }
 

--- a/src/core/tauri/spectaCommands.ts
+++ b/src/core/tauri/spectaCommands.ts
@@ -222,7 +222,7 @@ export const commands = {
       else return { status: 'error', error: e as any }
     }
   },
-  async getLookups(): Promise<Result<LookupState, CommandError>> {
+  async getLookups(): Promise<Result<LookupStateStringIds, CommandError>> {
     try {
       return { status: 'ok', data: await TAURI_INVOKE('get_lookups') }
     } catch (e) {
@@ -230,7 +230,7 @@ export const commands = {
       else return { status: 'error', error: e as any }
     }
   },
-  async addToLookups(newEntries: LookupState): Promise<Result<null, CommandError>> {
+  async addToLookups(newEntries: LookupStateStringIds): Promise<Result<null, CommandError>> {
     try {
       return { status: 'ok', data: await TAURI_INVOKE('add_to_lookups', { newEntries }) }
     } catch (e) {
@@ -351,7 +351,7 @@ export type LogFilterJs = {
 }
 export type LogLevel = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR'
 export type LogsResponse = { current: LogFilter; next: LogFilter; remaining_file_lines: LogEntry[] }
-export type LookupState = {
+export type LookupStateStringIds = {
   gen12: Partial<{ [key in string]: string }>
   gen345: Partial<{ [key in string]: string }>
 }

--- a/src/core/tauri/spectaCommands.ts
+++ b/src/core/tauri/spectaCommands.ts
@@ -118,9 +118,9 @@ export const commands = {
       else return { status: 'error', error: e as any }
     }
   },
-  async changeDataDir(): Promise<Result<null, CommandError>> {
+  async changeDataDir(shouldMove: boolean): Promise<Result<null, CommandError>> {
     try {
-      return { status: 'ok', data: await TAURI_INVOKE('change_data_dir') }
+      return { status: 'ok', data: await TAURI_INVOKE('change_data_dir', { shouldMove }) }
     } catch (e) {
       if (e instanceof Error) throw e
       else return { status: 'error', error: e as any }

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -106,17 +106,35 @@ function GeneralSettings() {
               <b>Current Data Directory:</b>
               <div>{dataDirPath}</div>
               <PromptDialog
+                title="Switch Data Directory"
+                description="Switch data directory? The app will restart using the specified directory as its datastore. No data will be copied or moved. THis is useful when you'd like to treat different directories as multiple 'profiles'. Note that Pokémon tracking data is independent per-directory."
+                triggerButton="Switch Profile"
+                actions={[
+                  { uniqueLabel: 'Cancel', action: () => {}, type: 'cancel' },
+                  {
+                    uniqueLabel: 'Select Directory...',
+                    action: () => {
+                      backend
+                        .promptChangeDataDir()
+                        .then(
+                          R.mapErr((err) => displayError('Error switching data directory', err))
+                        )
+                    },
+                  },
+                ]}
+              />
+              <PromptDialog
                 title="Move Data Directory?"
                 description="Are you sure you want to move the data directory? All files will be copied to the new location, and the app will restart. After they are copied to the new directory successfully, your storage and plugins will be removed from the old directory."
-                triggerButton="Change"
+                triggerButton="Move Data"
                 actions={[
                   { uniqueLabel: 'Cancel', action: () => {}, type: 'cancel' },
                   {
                     uniqueLabel: 'Select New Directory...',
                     action: () => {
                       backend
-                        .promptChangeDataDir()
-                        .then(R.mapErr((err) => displayError('Error changing data directory', err)))
+                        .promptMoveDataDir()
+                        .then(R.mapErr((err) => displayError('Error moving data', err)))
                     },
                     type: 'destructive',
                   },

--- a/src/ui/pages/tracked/Gen12Lookup.tsx
+++ b/src/ui/pages/tracked/Gen12Lookup.tsx
@@ -1,12 +1,18 @@
 import { OHPKM } from '@openhome-core/pkm/OHPKM'
 import { PluginIdentifier } from '@openhome-core/save/interfaces'
-import { gameOrPluginSorter, SortableColumn, stringSorter } from '@openhome-core/util/sort'
+import {
+  gameOrPluginSorter,
+  multiSorter,
+  numericSorter,
+  SortableColumn,
+  stringSorter,
+} from '@openhome-core/util/sort'
 import Badge from '@openhome-ui/components/badge/Badge'
 import PokemonIcon from '@openhome-ui/components/PokemonIcon'
 import SortableDataGrid from '@openhome-ui/components/SortableDataGrid'
 import { useLookups } from '@openhome-ui/state/lookups/useLookups'
 import { useOhpkmStore } from '@openhome-ui/state/ohpkm'
-import { OriginGames } from '@pkm-rs/pkg'
+import { Language, Lookup, OriginGames } from '@pkm-rs/pkg'
 
 type G12LookupRow = {
   gen12ID: string
@@ -40,6 +46,12 @@ export default function Gen12Lookup({ onSelectMon }: Gen12LookupProps) {
             />
           </button>
         ),
+      sortFunction: multiSorter(
+        numericSorter((row) => row.homeMon?.nationalDex),
+        numericSorter((row) => row.homeMon?.formIndex)
+      ),
+      getFilterValue: (value) =>
+        value.homeMon ? Lookup.speciesName(value.homeMon.nationalDex, Language.English) : undefined,
       cellClass: 'centered-cell',
     },
     {
@@ -86,6 +98,7 @@ export default function Gen12Lookup({ onSelectMon }: Gen12LookupProps) {
       }))}
       columns={columns}
       enableVirtualization={Object.entries(lookups.gen12).length > 2000} // maybe this should be user-togglable
+      defaultSort="Pokémon"
     />
   )
 }

--- a/src/ui/pages/tracked/Gen345Lookup.tsx
+++ b/src/ui/pages/tracked/Gen345Lookup.tsx
@@ -51,9 +51,7 @@ export default function Gen345Lookup({ onSelectMon }: Gen345LookupProps) {
         numericSorter((value) => value.homeMon?.formIndex)
       ),
       getFilterValue: (value) =>
-        value.homeMon?.nationalDex
-          ? Lookup.speciesName(value.homeMon?.nationalDex, Language.English)
-          : undefined,
+        value.homeMon ? Lookup.speciesName(value.homeMon.nationalDex, Language.English) : undefined,
     },
     {
       key: 'game',
@@ -99,7 +97,7 @@ export default function Gen345Lookup({ onSelectMon }: Gen345LookupProps) {
       }))}
       columns={columns}
       enableVirtualization={Object.entries(lookups.gen345).length > 2000} // maybe this should be user-togglable
-      style={{ width: '100%', flexGrow: 1 }}
+      defaultSort="Pokémon"
     />
   )
 }

--- a/src/ui/pokemon-details/PokemonDetailsModal.tsx
+++ b/src/ui/pokemon-details/PokemonDetailsModal.tsx
@@ -122,7 +122,10 @@ export default function PokemonDetailsModal(props: PokemonDetailsModalProps) {
             <div>Level {mon.getLevel()}</div>
             <div style={{ flex: 1 }} />
             {mon instanceof OHPKM && (
-              <div>Tracked since {mon.startedTrackingTimestamp?.format('MMMM D, YYYY')}</div>
+              <>
+                <div>OpenHome ID: {mon.openhomeId}</div>
+                <div>Tracked since {mon.startedTrackingTimestamp?.format('MMMM D, YYYY')}</div>
+              </>
             )}
           </div>
         </Dialog.Popup>

--- a/src/ui/state/ohpkm/useOhpkmStore.ts
+++ b/src/ui/state/ohpkm/useOhpkmStore.ts
@@ -24,6 +24,10 @@ export const FORCE_MISSED_LOOKUP = false
 
 export type MoveSlotIndex = 0 | 1 | 2 | 3
 
+function removeOriginIfPresent(id: string) {
+  return id.slice(0, 22)
+}
+
 export function useOhpkmStore() {
   const [ohpkmStore, updateStore] = useContext(OhpkmStoreContext)
   const { defaultConvertStrategy } = useConvertStrategies()
@@ -33,7 +37,7 @@ export function useOhpkmStore() {
 
   const getById = useCallback(
     (id: string): OHPKM | undefined => {
-      return ohpkmStore[id]
+      return ohpkmStore[removeOriginIfPresent(id)]
     },
     [ohpkmStore]
   )
@@ -325,11 +329,8 @@ export function useOhpkmStore() {
           }
 
           // because the game of origin may have been changed for legality reasons, we need to ignore the origin when looking up in the store
-          const homeIdentifierNoOrigin = homeIdentifier.split('-').slice(0, -1).join('-')
 
-          return Object.entries(ohpkmStore).find(([id, _]) =>
-            id.startsWith(homeIdentifierNoOrigin)
-          )?.[1]
+          return ohpkmStore[removeOriginIfPresent(homeIdentifier)]
         }
         default:
           expectExhaustive(mon.format, `unrecognized format: ${mon.format}`)


### PR DESCRIPTION
**Description**

- Permanently removing origin game from OpenHome ID and storing it inside the Pokémon as a 10-byte base evo national dex + trainer id + secred it + personality value struct
- Removed a full-ohpkm-store scan that was happening every time one was being retrieved

This version will include a migration that renames OHPKM files, so it should be a major release
