### PR TITLE
[FIX] fixed performance issue caused by on-save event listener

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -26,8 +26,9 @@ import { SavesProvider } from '@openhome-ui/state/saves'
 import ErrorMessageModal from '@openhome-ui/top-level/ErrorMessageModal'
 import UpdateMessageModal from '@openhome-ui/top-level/UpdateMessageModal'
 import { Flex, Text, Theme } from '@radix-ui/themes'
-import { useCallback, useEffect, useReducer, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useReducer, useState } from 'react'
 import BanksAndBoxesProvider from './state-zustand/banks-and-boxes/Provider'
+import { useBanksAndBoxes } from './state-zustand/banks-and-boxes/store'
 import ConvertStrategiesProvider from './state/convert-strategies/ConvertStrategiesProvider'
 import PluginsProvider from './state/plugin/PluginProvider'
 
@@ -52,7 +53,9 @@ export default function App() {
       <div id="app-container" className="root">
         <BackendContext value={TauriBackend}>
           <ErrorContext value={[errorState, errorDispatch]}>
-            <AppWithBackend />
+            <BanksAndBoxesProvider>
+              <AppWithBackend />
+            </BanksAndBoxesProvider>
           </ErrorContext>
         </BackendContext>
       </div>
@@ -65,6 +68,7 @@ function AppWithBackend() {
   const [dragState, setDragState] = useState<DragMonState>(emptyDragState())
   const [appInfoState, appInfoDispatch] = useReducer(appInfoReducer, appInfoInitialState)
   const [settingsLoading, setSettingsLoading] = useState(false)
+  const { saveChanges } = useBanksAndBoxes()
   const [bagState, bagDispatch] = useReducer(itemBagReducer, {
     itemCounts: {},
     modified: false,
@@ -77,6 +81,19 @@ function AppWithBackend() {
   const debouncedUpdateSettings = useDebounce((backend: BackendInterface, settings: Settings) => {
     backend.updateSettings(settings).catch(console.error)
   }, 500)
+
+  const listenForSave = useEffectEvent(() => {
+    // returns a function to stop listening
+    const stopListening = backend.onMenuEvent('save', saveChanges)
+
+    // the "stop listening" function should be called when the effect returns,
+    // otherwise duplicate listeners will exist
+    return () => {
+      stopListening()
+    }
+  })
+
+  useEffect(() => listenForSave(), [])
 
   // only on app start
   useEffect(() => {
@@ -145,41 +162,39 @@ function AppWithBackend() {
   }, [backend])
 
   return (
-    <BanksAndBoxesProvider>
-      <AppInfoContext value={[appInfoState, appInfoDispatch, getEnabledSaveTypes]}>
-        <PluginsProvider>
-          <TransactionStateProvider>
-            <MouseContext value={[mouseState, mouseDispatch]}>
-              <LookupsProvider>
-                <ConvertStrategiesProvider>
-                  <OhpkmStoreProvider>
-                    <ItemBagContext value={[bagState, bagDispatch]}>
-                      <SavesProvider>
-                        <DragMonContext value={[dragState, setDragState]}>
-                          <PokemonDndContext>
-                            {settingsLoading ? (
-                              <Flex width="100%" height="100vh" align="center" justify="center">
-                                <Text size="9" weight="bold">
-                                  OpenHome
-                                </Text>
-                              </Flex>
-                            ) : (
-                              <AppTabs />
-                            )}
-                            <ErrorMessageModal />
-                            <UpdateMessageModal />
-                          </PokemonDndContext>
-                        </DragMonContext>
-                      </SavesProvider>
-                    </ItemBagContext>
-                  </OhpkmStoreProvider>
-                </ConvertStrategiesProvider>
-              </LookupsProvider>
-            </MouseContext>
-          </TransactionStateProvider>
-        </PluginsProvider>
-      </AppInfoContext>
-    </BanksAndBoxesProvider>
+    <AppInfoContext value={[appInfoState, appInfoDispatch, getEnabledSaveTypes]}>
+      <PluginsProvider>
+        <TransactionStateProvider>
+          <MouseContext value={[mouseState, mouseDispatch]}>
+            <LookupsProvider>
+              <ConvertStrategiesProvider>
+                <OhpkmStoreProvider>
+                  <ItemBagContext value={[bagState, bagDispatch]}>
+                    <SavesProvider>
+                      <DragMonContext value={[dragState, setDragState]}>
+                        <PokemonDndContext>
+                          {settingsLoading ? (
+                            <Flex width="100%" height="100vh" align="center" justify="center">
+                              <Text size="9" weight="bold">
+                                OpenHome
+                              </Text>
+                            </Flex>
+                          ) : (
+                            <AppTabs />
+                          )}
+                          <ErrorMessageModal />
+                          <UpdateMessageModal />
+                        </PokemonDndContext>
+                      </DragMonContext>
+                    </SavesProvider>
+                  </ItemBagContext>
+                </OhpkmStoreProvider>
+              </ConvertStrategiesProvider>
+            </LookupsProvider>
+          </MouseContext>
+        </TransactionStateProvider>
+      </PluginsProvider>
+    </AppInfoContext>
   )
 }
 

--- a/src/ui/state-zustand/banks-and-boxes/store.ts
+++ b/src/ui/state-zustand/banks-and-boxes/store.ts
@@ -10,7 +10,7 @@ import {
 import { Option, partitionResults, R, range, Result } from '@openhome-core/util/functional'
 import { numericSorter } from '@openhome-core/util/sort'
 import { IdentifierNotPresentError, useOhpkmStore } from '@openhome-ui/state/ohpkm'
-import { createContext, useCallback, useContext, useEffect } from 'react'
+import { createContext, useCallback, useContext } from 'react'
 import { v4 as UuidV4 } from 'uuid'
 import { create, StateCreator, StoreApi, UseBoundStore } from 'zustand'
 import { immer } from 'zustand/middleware/immer'
@@ -586,17 +586,6 @@ export function useBanksAndBoxes() {
     })
     await reloadBankStore()
   }, [backend, banks, getCurrentBank, reloadBankStore])
-
-  useEffect(() => {
-    // returns a function to stop listening
-    const stopListening = backend.onMenuEvent('save', saveChanges)
-
-    // the "stop listening" function should be called when the effect returns,
-    // otherwise duplicate listeners will exist
-    return () => {
-      stopListening()
-    }
-  }, [backend, saveChanges, reloadBankStore])
 
   return {
     saveChanges,


### PR DESCRIPTION
the banks/boxes store hook is where the app was listening for the save event from the backend, but that hook was being called by every component that needed access to the banks/boxes store. This meant the app would freeze sometimes as every component decided to unlisten/relisten at once.
